### PR TITLE
Testing: add dummy metric

### DIFF
--- a/docs/journal.tex
+++ b/docs/journal.tex
@@ -68,6 +68,25 @@ The correlation coefficient $\rho$ ranges from -1 to 1, where:
 
 The evaluation of AI assistant interactions requires robust mechanisms to detect and mitigate potential biases and risks. This section presents a comprehensive framework for bias assessment and risk detection using the Granite Guardian model \cite{ibm2024granite} and AI ATLAS risk framework \cite{ibm2024atlas}.
 
+\section{Levenshtein Distance Metric}
+
+The Levenshtein distance between two strings \( a = a_1 a_2 \dots a_m \) and \( b = b_1 b_2 \dots b_n \) is defined as the minimum number of single-character edits (insertions, deletions, or substitutions) required to transform one string into the other. It is formally computed using dynamic programming:
+
+\[
+D(i, j) = 
+\begin{cases}
+\max(i, j) & \text{if } \min(i, j) = 0 \\
+\min
+\begin{cases}
+D(i - 1, j) + 1 \\
+D(i, j - 1) + 1 \\
+D(i - 1, j - 1) + [a_i \ne b_j]
+\end{cases} & \text{otherwise}
+\end{cases}
+\]
+
+Where \( D(i, j) \) represents the Levenshtein distance between the first \( i \) characters of \( a \) and the first \( j \) characters of \( b \), and \([a_i \ne b_j]\) is 0 if \( a_i = b_j \), and 1 otherwise.
+
 \subsection{Risk Detection Framework}
 
 The risk assessment framework operates across three primary dimensions:

--- a/fair_forge/metrics/levenshtein_distance.py
+++ b/fair_forge/metrics/levenshtein_distance.py
@@ -1,0 +1,50 @@
+from fair_forge import FairForge, Retriever
+from typing import Type, Optional
+from fair_forge.schemas import Batch, ContextMetric
+
+class LevenshteinDistance(FairForge):
+    def __init__(self, retriever: Type[Retriever], **kwargs):
+        super().__init__(retriever, **kwargs)
+
+    def batch(
+        self,
+        session_id: str,
+        context: str,
+        assistant_id: str,
+        batch: list[Batch],
+        language: Optional[str] = "english",
+    ):
+        # Implement your metric logic here
+        for interaction in batch:
+            # Process each interaction
+            distance = self._compute_distance(interaction.ground_truth_assistant, interaction.assistant)
+
+            metric = LevenshteinDistanceMetric(
+                    levenshtein_distance=distance,
+                    session_id=session_id,
+                    assistant_id=assistant_id,
+                    qa_id=interaction.qa_id,
+                )
+
+            self.metrics.append(metric)
+
+    def _compute_distance(self, s1: str, s2: str) -> int:
+        """
+        Computes the Levenshtein distance between two sentences.
+        This measures how many single-character edits (insertions, deletions, substitutions)
+        are needed to transform one sentence into the other.
+        """
+        if len(s1) < len(s2):
+            return levenshtein_distance(s2, s1)
+
+        previous_row = range(len(s2) + 1)
+        for i, c1 in enumerate(s1):
+            current_row = [i + 1]
+            for j, c2 in enumerate(s2):
+                insertions = previous_row[j + 1] + 1
+                deletions = current_row[j] + 1
+                substitutions = previous_row[j] + (c1 != c2)
+                current_row.append(min(insertions, deletions, substitutions))
+            previous_row = current_row
+
+        return previous_row[-1]

--- a/fair_forge/schemas.py
+++ b/fair_forge/schemas.py
@@ -111,3 +111,10 @@ class HumanityMetric(Metric):
 
 class AgenticMetric(Metric):
     pass
+
+class LevenshteinDistanceMetric(Metric):
+    """
+    Levenshtein metric for measuring the similarity between the assistant response and expected answer.
+    """
+
+    levenshtein_distance: int


### PR DESCRIPTION
I followed the CONTRIBUTING documentation to implement a new metric: The 'Levenshtein Distance' measures how many single-character edits (insertions, deletions, substitutions) are needed to transform one sentence into the other.

This metric has no real value of implementation and this PR serves only for testing.

Ps: DO NOT MERGE!