### PR TITLE
fix(agentic): evaluate tool correctness for all K responses

### DIFF
--- a/docs/metrics/agentic.mdx
+++ b/docs/metrics/agentic.mdx
@@ -13,7 +13,11 @@ This metric evaluates:
 
 - **pass@K**: At least one of K responses is correct (similarity ≥ threshold)
 - **pass^K**: All K responses are correct
-- **Tool Correctness**: Evaluates tool selection, parameter accuracy, execution sequence, and result utilization
+- **Tool Correctness**: Evaluates tool selection, parameter accuracy, execution sequence, and result utilization **for each of K responses**
+
+<Note>
+**Important:** The metric evaluates tool correctness for **ALL K responses**, not just one. This allows you to identify which responses had correct tool usage and which didn't. The default `tool_threshold=1.0` requires perfect tool usage (100% correct).
+</Note>
 
 ## Installation
 
@@ -41,7 +45,7 @@ metrics = Agentic.run(
     AgenticRetriever,
     model=judge_model,
     threshold=0.7,
-    tool_threshold=0.75,
+    tool_threshold=1.0,
     verbose=True,
 )
 
@@ -49,8 +53,12 @@ metrics = Agentic.run(
 for metric in metrics:
     print(f"pass@{metric.k}: {metric.pass_at_k}")
     print(f"pass^{metric.k}: {metric.pass_pow_k}")
-    if metric.tool_correctness:
-        print(f"Tool correctness: {metric.tool_correctness.overall_correctness:.2f}")
+
+    # Tool correctness scores for each of K responses
+    if metric.tool_correctness_scores:
+        for i, tc in enumerate(metric.tool_correctness_scores):
+            if tc:
+                print(f"Response {i+1} tool correctness: {tc.overall_correctness:.2f}")
 ```
 
 ## Parameters
@@ -67,7 +75,7 @@ for metric in metrics:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `threshold` | `float` | `0.7` | Answer correctness threshold (0.6-0.9) |
-| `tool_threshold` | `float` | `0.75` | Tool correctness threshold (0.6-0.9) |
+| `tool_threshold` | `float` | `1.0` | Tool correctness threshold (0.6-1.0) - requires perfect tool usage |
 | `tool_weights` | `dict[str, float]` | `0.25` each | Weights for tool aspects (selection, parameters, sequence, utilization) |
 | `use_structured_output` | `bool` | `False` | Use LangChain structured output |
 | `bos_json_clause` | `str` | `"```json"` | JSON block start marker |
@@ -178,13 +186,13 @@ class AgenticMetric(BaseMetric):
     session_id: str
     assistant_id: str
     qa_id: str
-    k: int                          # Number of responses evaluated
-    threshold: float                # Answer correctness threshold
-    correctness_scores: list[float] # Individual scores for each response
-    pass_at_k: bool                 # At least one correct
-    pass_pow_k: bool                # All correct
-    correct_indices: list[int]      # Indices of correct responses
-    tool_correctness: ToolCorrectnessScore | None  # Optional tool evaluation
+    k: int                                        # Number of responses evaluated
+    threshold: float                              # Answer correctness threshold
+    correctness_scores: list[float]               # Individual scores for each response
+    pass_at_k: bool                               # At least one correct
+    pass_pow_k: bool                              # All correct
+    correct_indices: list[int]                    # Indices of correct responses
+    tool_correctness_scores: list[ToolCorrectnessScore | None]  # Tool evaluation for each K response
 ```
 
 ### ToolCorrectnessScore
@@ -213,13 +221,18 @@ class ToolCorrectnessScore(BaseModel):
 
 ### Tool Correctness Scores
 
+<Note>
+**Default threshold: 1.0** - By default, tool correctness requires perfect execution (100% correct). You can lower this with the `tool_threshold` parameter if you want to allow minor deviations.
+</Note>
+
 | Score Range | Interpretation |
 |-------------|----------------|
-| 0.9 - 1.0 | Excellent - Perfect tool usage |
-| 0.75 - 0.9 | Good - Minor issues |
-| 0.6 - 0.75 | Moderate - Several issues |
-| 0.4 - 0.6 | Poor - Significant problems |
-| 0.0 - 0.4 | Very Poor - Incorrect tool usage |
+| **1.0** | **Perfect - All aspects correct (default threshold)** |
+| 0.9 - 0.99 | Excellent - Near perfect with tiny issues |
+| 0.75 - 0.89 | Good - Minor issues |
+| 0.6 - 0.74 | Moderate - Several issues |
+| 0.4 - 0.59 | Poor - Significant problems |
+| 0.0 - 0.39 | Very Poor - Incorrect tool usage |
 
 ### Tool Aspects
 
@@ -331,7 +344,7 @@ metrics = Agentic.run(
     MathAgentRetriever,
     model=judge,
     threshold=0.7,
-    tool_threshold=0.75,
+    tool_threshold=1.0,
     verbose=True,
 )
 
@@ -347,22 +360,34 @@ for metric in metrics:
     print(f"Correct responses: {len(metric.correct_indices)}/{metric.k}")
     print(f"Individual scores: {[f'{s:.2f}' for s in metric.correctness_scores]}")
 
-    if metric.tool_correctness:
-        tc = metric.tool_correctness
-        print(f"\nTool Correctness:")
-        print(f"  Selection: {tc.tool_selection_correct:.2f}")
-        print(f"  Parameters: {tc.parameter_accuracy:.2f}")
-        print(f"  Sequence: {tc.sequence_correct:.2f}")
-        print(f"  Utilization: {tc.result_utilization:.2f}")
-        print(f"  Overall: {tc.overall_correctness:.2f} {'✓' if tc.is_correct else '✗'}")
-        print(f"  Reasoning: {tc.reasoning}")
+    # Tool correctness for each of K responses
+    if metric.tool_correctness_scores:
+        print(f"\nTool Correctness (K={metric.k} responses):")
+        for i, tc in enumerate(metric.tool_correctness_scores, 1):
+            if tc:
+                print(f"\n  Response {i}:")
+                print(f"    Selection:    {tc.tool_selection_correct:.2f}")
+                print(f"    Parameters:   {tc.parameter_accuracy:.2f}")
+                print(f"    Sequence:     {tc.sequence_correct:.2f}")
+                print(f"    Utilization:  {tc.result_utilization:.2f}")
+                print(f"    Overall:      {tc.overall_correctness:.2f} {'✓' if tc.is_correct else '✗'}")
+                if tc.reasoning:
+                    print(f"    Reasoning:    {tc.reasoning}")
+            else:
+                print(f"\n  Response {i}: No tools used")
 
 # Calculate aggregate statistics
 total_pass_at_k = sum(m.pass_at_k for m in metrics)
 total_pass_pow_k = sum(m.pass_pow_k for m in metrics)
-avg_tool_correctness = sum(
-    m.tool_correctness.overall_correctness for m in metrics if m.tool_correctness
-) / len([m for m in metrics if m.tool_correctness])
+
+# Average tool correctness across all responses
+all_tool_scores = [
+    tc.overall_correctness
+    for m in metrics
+    for tc in m.tool_correctness_scores
+    if tc is not None
+]
+avg_tool_correctness = sum(all_tool_scores) / len(all_tool_scores) if all_tool_scores else 0.0
 
 print(f"\n{'=' * 60}")
 print(f"Aggregate Statistics:")
@@ -413,6 +438,47 @@ model = ChatOllama(
 )
 ```
 </CodeGroup>
+
+## Understanding Tool Correctness for K Responses
+
+The metric evaluates tool correctness **independently for each of K responses**. This helps identify:
+- Which responses had correct tool usage
+- Common patterns in tool mistakes
+- Whether better answers correlate with better tool usage
+
+### Example with K=3
+
+```python
+# Assume we have K=3 responses for "What is 5 + 7?"
+# Response 1: Uses calculator with correct parameters → Overall: 1.0 ✓
+# Response 2: Uses calculator with WRONG parameters (a=5, b=8) → Overall: 0.75 ✗
+# Response 3: Doesn't use tools at all → tool_correctness_scores[2] = None
+
+metrics = Agentic.run(AgenticRetriever, model=judge_model, tool_threshold=1.0)
+
+for metric in metrics:
+    # metric.tool_correctness_scores = [ToolCorrectnessScore(...), ToolCorrectnessScore(...), None]
+    print(f"Response 1 tool score: {metric.tool_correctness_scores[0].overall_correctness}")  # 1.0
+    print(f"Response 2 tool score: {metric.tool_correctness_scores[1].overall_correctness}")  # 0.75
+    print(f"Response 3 tool score: {metric.tool_correctness_scores[2]}")  # None
+```
+
+### Why tool_threshold=1.0 by Default?
+
+Tool usage is **deterministic** - either the agent called the right tool with right parameters or it didn't. Unlike answer correctness (which can be subjective), tool correctness should be strict:
+
+- **1.0 (Perfect)**: Agent used exactly the right tools, parameters, sequence, and utilized results
+- **<1.0 (Imperfect)**: Something was wrong - wrong tool, wrong params, wrong order, or didn't use results
+
+If you want to allow **small deviations** (e.g., extra parameters that don't affect the result), lower the threshold:
+
+```python
+metrics = Agentic.run(
+    AgenticRetriever,
+    model=judge_model,
+    tool_threshold=0.9,  # Allow 10% deviation
+)
+```
 
 ## Custom Tool Weights
 
@@ -493,13 +559,28 @@ metrics = Agentic.run(
   </Accordion>
 
   <Accordion title="Tool Correctness Always Fails">
-    **Cause**: `ground_truth_agentic` expectations don't match actual tool usage.
+    **Cause**: Default `tool_threshold=1.0` requires perfect tool usage, or `ground_truth_agentic` expectations don't match actual tool usage.
 
     **Solution**:
-    - Verify tool names match exactly
-    - Check parameter structure (keys and values)
+    - **Lower the threshold** if you want to allow small deviations: `tool_threshold=0.9`
+    - Verify tool names match exactly (case-sensitive)
+    - Check parameter structure (keys and values must match exactly)
     - Confirm step numbers if sequence matters
     - Set `tool_sequence_matters: False` if order doesn't matter
+    - Check each response's tool score individually: `metric.tool_correctness_scores[i]`
+  </Accordion>
+
+  <Accordion title="Some Responses Have None for Tool Correctness">
+    **Cause**: Not all K responses used tools, which is expected behavior.
+
+    **Solution**:
+    - This is normal - `tool_correctness_scores[i]` will be `None` if response didn't use tools
+    - Check if tools were needed: `batch.agentic.get('tools_used', [])`
+    - Filter out None values when calculating averages:
+      ```python
+      valid_scores = [tc for tc in metric.tool_correctness_scores if tc is not None]
+      avg = sum(tc.overall_correctness for tc in valid_scores) / len(valid_scores)
+      ```
   </Accordion>
 
   <Accordion title="Multiple Datasets with Same qa_id Not Grouping">

--- a/examples/agentic/aws-lambda/README.md
+++ b/examples/agentic/aws-lambda/README.md
@@ -255,15 +255,27 @@ curl -s -X POST "<INVOKE_URL>/run" \
       "pass_pow_k": false,
       "correctness_scores": [0.85, 0.92, 0.65],
       "correct_indices": [0, 1],
-      "tool_correctness": {
-        "tool_selection_correct": 1.0,
-        "parameter_accuracy": 1.0,
-        "sequence_correct": 1.0,
-        "result_utilization": 1.0,
-        "overall_correctness": 1.0,
-        "is_correct": true,
-        "reasoning": "All tools used correctly"
-      }
+      "tool_correctness_scores": [
+        {
+          "tool_selection_correct": 1.0,
+          "parameter_accuracy": 1.0,
+          "sequence_correct": 1.0,
+          "result_utilization": 1.0,
+          "overall_correctness": 1.0,
+          "is_correct": true,
+          "reasoning": "All tools used correctly"
+        },
+        {
+          "tool_selection_correct": 1.0,
+          "parameter_accuracy": 0.5,
+          "sequence_correct": 1.0,
+          "result_utilization": 1.0,
+          "overall_correctness": 0.875,
+          "is_correct": false,
+          "reasoning": "Incorrect parameter values"
+        },
+        null
+      ]
     }
   ],
   "count": 1,
@@ -288,14 +300,14 @@ curl -s -X POST "<INVOKE_URL>/run" \
 | `metrics[].pass_pow_k` | boolean | All responses are correct |
 | `metrics[].correctness_scores` | array | Correctness scores for each response (0.0-1.0) |
 | `metrics[].correct_indices` | array | Indices of correct responses (score >= threshold) |
-| `metrics[].tool_correctness` | object | Tool usage evaluation (if ground_truth_agentic provided) |
-| `metrics[].tool_correctness.tool_selection_correct` | float | Tool selection score (0.0-1.0) |
-| `metrics[].tool_correctness.parameter_accuracy` | float | Parameter accuracy score (0.0-1.0) |
-| `metrics[].tool_correctness.sequence_correct` | float | Sequence correctness score (0.0-1.0) |
-| `metrics[].tool_correctness.result_utilization` | float | Result utilization score (0.0-1.0) |
-| `metrics[].tool_correctness.overall_correctness` | float | Weighted average of all components |
-| `metrics[].tool_correctness.is_correct` | boolean | Overall correctness >= tool_threshold |
-| `metrics[].tool_correctness.reasoning` | string | Optional explanation |
+| `metrics[].tool_correctness_scores` | array | Tool usage evaluation for each of K responses (if ground_truth_agentic provided) |
+| `metrics[].tool_correctness_scores[].tool_selection_correct` | float | Tool selection score (0.0-1.0) |
+| `metrics[].tool_correctness_scores[].parameter_accuracy` | float | Parameter accuracy score (0.0-1.0) |
+| `metrics[].tool_correctness_scores[].sequence_correct` | float | Sequence correctness score (0.0-1.0) |
+| `metrics[].tool_correctness_scores[].result_utilization` | float | Result utilization score (0.0-1.0) |
+| `metrics[].tool_correctness_scores[].overall_correctness` | float | Weighted average of all components |
+| `metrics[].tool_correctness_scores[].is_correct` | boolean | Overall correctness >= tool_threshold |
+| `metrics[].tool_correctness_scores[].reasoning` | string | Optional explanation |
 | `count` | integer | Total number of qa_ids evaluated |
 | `summary.total_qa_ids` | integer | Total questions evaluated |
 | `summary.pass_at_k_count` | integer | Number of questions with pass@K=true |

--- a/examples/agentic/aws-lambda/run.py
+++ b/examples/agentic/aws-lambda/run.py
@@ -226,16 +226,21 @@ def run(payload: dict) -> dict[str, Any]:
             "correct_indices": metric.correct_indices,
         }
 
-        if metric.tool_correctness:
-            result["tool_correctness"] = {
-                "tool_selection_correct": metric.tool_correctness.tool_selection_correct,
-                "parameter_accuracy": metric.tool_correctness.parameter_accuracy,
-                "sequence_correct": metric.tool_correctness.sequence_correct,
-                "result_utilization": metric.tool_correctness.result_utilization,
-                "overall_correctness": metric.tool_correctness.overall_correctness,
-                "is_correct": metric.tool_correctness.is_correct,
-                "reasoning": metric.tool_correctness.reasoning,
-            }
+        if metric.tool_correctness_scores:
+            result["tool_correctness_scores"] = [
+                {
+                    "tool_selection_correct": tc.tool_selection_correct,
+                    "parameter_accuracy": tc.parameter_accuracy,
+                    "sequence_correct": tc.sequence_correct,
+                    "result_utilization": tc.result_utilization,
+                    "overall_correctness": tc.overall_correctness,
+                    "is_correct": tc.is_correct,
+                    "reasoning": tc.reasoning,
+                }
+                if tc
+                else None
+                for tc in metric.tool_correctness_scores
+            ]
 
         results.append(result)
 

--- a/examples/agentic/jupyter/agentic.ipynb
+++ b/examples/agentic/jupyter/agentic.ipynb
@@ -1,468 +1,488 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "intro",
-      "metadata": {},
-      "source": [
-        "# Agentic Metric Example\n",
-        "\n",
-        "This notebook demonstrates how to use the **Agentic** metric from Fair Forge to evaluate AI agent responses with pass@K and tool correctness.\n",
-        "\n",
-        "The metric evaluates:\n",
-        "- **pass@K**: At least one of K responses is correct (score >= threshold)\n",
-        "- **pass^K**: All K responses are correct\n",
-        "- **Tool Correctness**: Proper tool usage across 4 dimensions:\n",
-        "  - Selection (25%): Were the correct tools chosen?\n",
-        "  - Parameters (25%): Were correct parameters passed?\n",
-        "  - Sequence (25%): Were tools used in the correct order?\n",
-        "  - Utilization (25%): Were tool results used in the final answer?"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "install-header",
-      "metadata": {},
-      "source": [
-        "## Installation\n",
-        "\n",
-        "First, install Fair Forge with agentic support and required dependencies."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "install",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "!pip install \"alquimia-fair-forge[agentic]\" langchain-groq -q"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "setup-header",
-      "metadata": {},
-      "source": [
-        "## Setup\n",
-        "\n",
-        "Import required modules and configure your API key."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "imports",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "import sys\n",
-        "from pathlib import Path\n",
-        "\n",
-        "# Add examples directory to path for local imports\n",
-        "sys.path.insert(0, str(Path(\"../..\").resolve()))\n",
-        "\n",
-        "from langchain_groq import ChatGroq\n",
-        "\n",
-        "from fair_forge import Retriever\n",
-        "from fair_forge.metrics.agentic import Agentic\n",
-        "from fair_forge.schemas import Dataset"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "api-key",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "import getpass\n",
-        "\n",
-        "GROQ_API_KEY = getpass.getpass(\"Enter your Groq API key: \")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "retriever-header",
-      "metadata": {},
-      "source": [
-        "## Create an Agentic Retriever\n",
-        "\n",
-        "The Agentic metric requires **K datasets with the same qa_id** but different assistant_id values. Each dataset represents one agent response.\n",
-        "\n",
-        "In our example, we have K=3 responses for each question."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "retriever",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "class AgenticRetriever(Retriever):\n",
-        "    \"\"\"Retriever that loads K agent responses for the same questions.\"\"\"\n",
-        "\n",
-        "    def load_dataset(self) -> list[Dataset]:\n",
-        "        dataset_path = Path(\"dataset_agentic.json\")\n",
-        "        datasets = []\n",
-        "        with open(dataset_path) as infile:\n",
-        "            for dataset in json.load(infile):\n",
-        "                datasets.append(Dataset.model_validate(dataset))\n",
-        "        return datasets"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "preview-header",
-      "metadata": {},
-      "source": [
-        "## Preview the Dataset\n",
-        "\n",
-        "Let's see the structure of our test dataset."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "preview",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "retriever = AgenticRetriever()\n",
-        "datasets = retriever.load_dataset()\n",
-        "\n",
-        "print(f\"Number of agent responses (K): {len(datasets)}\")\n",
-        "print(f\"\\nAgent IDs: {[ds.assistant_id for ds in datasets]}\")\n",
-        "print(f\"Number of questions: {len(datasets[0].conversation)}\")\n",
-        "\n",
-        "print(\"\\nQuestions (qa_ids):\")\n",
-        "for batch in datasets[0].conversation:\n",
-        "    print(f\"  - {batch.qa_id}: {batch.query}\")\n",
-        "\n",
-        "print(\"\\nSample responses for first question:\")\n",
-        "for ds in datasets:\n",
-        "    batch = ds.conversation[0]\n",
-        "    print(f\"\\n{ds.assistant_id}:\")\n",
-        "    print(f\"  Answer: {batch.assistant}\")\n",
-        "    print(f\"  Tools used: {len(batch.agentic['tools_used'])} tool(s)\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "model-header",
-      "metadata": {},
-      "source": [
-        "## Initialize the Judge Model\n",
-        "\n",
-        "The Agentic metric uses an LLM judge to evaluate answer correctness."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "model",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "judge_model = ChatGroq(\n",
-        "    model=\"llama-3.3-70b-versatile\",\n",
-        "    api_key=GROQ_API_KEY,\n",
-        "    temperature=0.0,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "run-header",
-      "metadata": {},
-      "source": [
-        "## Run the Agentic Metric\n",
-        "\n",
-        "The metric will evaluate:\n",
-        "1. Answer correctness for each of K responses\n",
-        "2. pass@K: At least one response is correct\n",
-        "3. pass^K: All responses are correct\n",
-        "4. Tool correctness: Proper tool usage"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "run",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "metrics = Agentic.run(\n",
-        "    AgenticRetriever,\n",
-        "    model=judge_model,\n",
-        "    threshold=0.7,\n",
-        "    tool_threshold=0.75,\n",
-        "    use_structured_output=False,\n",
-        "    verbose=True,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "analyze-header",
-      "metadata": {},
-      "source": [
-        "## Analyze Results\n",
-        "\n",
-        "Let's examine the evaluation results for each question."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "analyze",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "print(f\"Total metrics: {len(metrics)}\\n\")\n",
-        "print(\"=\" * 70)\n",
-        "\n",
-        "for metric in metrics:\n",
-        "    print(f\"\\nQuestion ID: {metric.qa_id}\")\n",
-        "    print(f\"K (responses): {metric.k}\")\n",
-        "    print(f\"Threshold: {metric.threshold}\")\n",
-        "    print(f\"\\nCorrectness scores: {[f'{s:.2f}' for s in metric.correctness_scores]}\")\n",
-        "    print(f\"Correct indices: {metric.correct_indices}\")\n",
-        "    print(f\"\\npass@{metric.k}: {metric.pass_at_k} ({'\u2713' if metric.pass_at_k else '\u2717'})\")\n",
-        "    print(f\"pass^{metric.k}: {metric.pass_pow_k} ({'\u2713' if metric.pass_pow_k else '\u2717'})\")\n",
-        "    \n",
-        "    if metric.tool_correctness:\n",
-        "        tc = metric.tool_correctness\n",
-        "        print(f\"\\nTool Correctness:\")\n",
-        "        print(f\"  Selection:    {tc.tool_selection_correct:.2f}\")\n",
-        "        print(f\"  Parameters:   {tc.parameter_accuracy:.2f}\")\n",
-        "        print(f\"  Sequence:     {tc.sequence_correct:.2f}\")\n",
-        "        print(f\"  Utilization:  {tc.result_utilization:.2f}\")\n",
-        "        print(f\"  Overall:      {tc.overall_correctness:.2f} ({'\u2713' if tc.is_correct else '\u2717'})\")\n",
-        "    \n",
-        "    print(\"\\n\" + \"-\" * 70)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "summary-header",
-      "metadata": {},
-      "source": [
-        "## Summary Statistics"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "summary",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "pass_at_k_count = sum(1 for m in metrics if m.pass_at_k)\n",
-        "pass_pow_k_count = sum(1 for m in metrics if m.pass_pow_k)\n",
-        "tool_correct_count = sum(1 for m in metrics if m.tool_correctness and m.tool_correctness.is_correct)\n",
-        "\n",
-        "print(\"Summary Statistics:\")\n",
-        "print(f\"Total questions evaluated: {len(metrics)}\")\n",
-        "print(f\"\\npass@K success rate: {pass_at_k_count}/{len(metrics)} ({pass_at_k_count/len(metrics)*100:.1f}%)\")\n",
-        "print(f\"pass^K success rate: {pass_pow_k_count}/{len(metrics)} ({pass_pow_k_count/len(metrics)*100:.1f}%)\")\n",
-        "print(f\"Tool correctness rate: {tool_correct_count}/{len(metrics)} ({tool_correct_count/len(metrics)*100:.1f}%)\")\n",
-        "\n",
-        "avg_score = sum(sum(m.correctness_scores) for m in metrics) / sum(len(m.correctness_scores) for m in metrics)\n",
-        "print(f\"\\nAverage correctness score: {avg_score:.3f}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "viz-header",
-      "metadata": {},
-      "source": [
-        "## Visualize Results"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "viz",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "\n",
-        "fig, axes = plt.subplots(2, 2, figsize=(14, 10))\n",
-        "\n",
-        "# Plot 1: Correctness scores by question\n",
-        "ax1 = axes[0, 0]\n",
-        "qa_ids = [m.qa_id for m in metrics]\n",
-        "x_pos = np.arange(len(qa_ids))\n",
-        "\n",
-        "for i in range(metrics[0].k):\n",
-        "    scores = [m.correctness_scores[i] if i < len(m.correctness_scores) else 0 for m in metrics]\n",
-        "    ax1.bar(x_pos + i*0.25, scores, 0.25, label=f'Response {i+1}', alpha=0.8)\n",
-        "\n",
-        "ax1.axhline(y=0.7, color='r', linestyle='--', label='Threshold')\n",
-        "ax1.set_xlabel('Question')\n",
-        "ax1.set_ylabel('Correctness Score')\n",
-        "ax1.set_title('Correctness Scores by Question and Response')\n",
-        "ax1.set_xticks(x_pos + 0.25)\n",
-        "ax1.set_xticklabels([qa.replace('_', '\\n') for qa in qa_ids], rotation=0, ha='center')\n",
-        "ax1.legend()\n",
-        "ax1.grid(axis='y', alpha=0.3)\n",
-        "\n",
-        "# Plot 2: pass@K vs pass^K\n",
-        "ax2 = axes[0, 1]\n",
-        "pass_at_k = [m.pass_at_k for m in metrics]\n",
-        "pass_pow_k = [m.pass_pow_k for m in metrics]\n",
-        "x = np.arange(len(qa_ids))\n",
-        "width = 0.35\n",
-        "\n",
-        "ax2.bar(x - width/2, pass_at_k, width, label='pass@K', color='green', alpha=0.7)\n",
-        "ax2.bar(x + width/2, pass_pow_k, width, label='pass^K', color='blue', alpha=0.7)\n",
-        "ax2.set_xlabel('Question')\n",
-        "ax2.set_ylabel('Result (True/False)')\n",
-        "ax2.set_title('pass@K vs pass^K by Question')\n",
-        "ax2.set_xticks(x)\n",
-        "ax2.set_xticklabels([qa.replace('_', '\\n') for qa in qa_ids], rotation=0, ha='center')\n",
-        "ax2.set_yticks([0, 1])\n",
-        "ax2.set_yticklabels(['False', 'True'])\n",
-        "ax2.legend()\n",
-        "ax2.grid(axis='y', alpha=0.3)\n",
-        "\n",
-        "# Plot 3: Tool correctness components\n",
-        "ax3 = axes[1, 0]\n",
-        "components = ['Selection', 'Parameters', 'Sequence', 'Utilization']\n",
-        "x_pos = np.arange(len(components))\n",
-        "\n",
-        "for i, m in enumerate(metrics):\n",
-        "    if m.tool_correctness:\n",
-        "        tc = m.tool_correctness\n",
-        "        scores = [\n",
-        "            tc.tool_selection_correct,\n",
-        "            tc.parameter_accuracy,\n",
-        "            tc.sequence_correct,\n",
-        "            tc.result_utilization\n",
-        "        ]\n",
-        "        ax3.plot(x_pos, scores, marker='o', label=m.qa_id, linewidth=2)\n",
-        "\n",
-        "ax3.axhline(y=0.75, color='r', linestyle='--', label='Threshold', alpha=0.5)\n",
-        "ax3.set_xlabel('Component')\n",
-        "ax3.set_ylabel('Score')\n",
-        "ax3.set_title('Tool Correctness Components by Question')\n",
-        "ax3.set_xticks(x_pos)\n",
-        "ax3.set_xticklabels(components)\n",
-        "ax3.legend()\n",
-        "ax3.grid(True, alpha=0.3)\n",
-        "ax3.set_ylim(0, 1.05)\n",
-        "\n",
-        "# Plot 4: Overall metrics summary\n",
-        "ax4 = axes[1, 1]\n",
-        "metrics_data = [\n",
-        "    pass_at_k_count / len(metrics),\n",
-        "    pass_pow_k_count / len(metrics),\n",
-        "    tool_correct_count / len(metrics),\n",
-        "    avg_score\n",
-        "]\n",
-        "metric_names = ['pass@K\\nRate', 'pass^K\\nRate', 'Tool\\nCorrect Rate', 'Avg\\nScore']\n",
-        "colors = ['green', 'blue', 'orange', 'purple']\n",
-        "\n",
-        "bars = ax4.bar(metric_names, metrics_data, color=colors, alpha=0.7)\n",
-        "ax4.set_ylabel('Rate / Score')\n",
-        "ax4.set_title('Overall Metrics Summary')\n",
-        "ax4.set_ylim(0, 1.05)\n",
-        "ax4.grid(axis='y', alpha=0.3)\n",
-        "\n",
-        "for bar, value in zip(bars, metrics_data):\n",
-        "    height = bar.get_height()\n",
-        "    ax4.text(bar.get_x() + bar.get_width()/2., height + 0.02,\n",
-        "             f'{value:.2f}', ha='center', va='bottom', fontweight='bold')\n",
-        "\n",
-        "plt.tight_layout()\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "understanding",
-      "metadata": {},
-      "source": [
-        "## Understanding the Results\n",
-        "\n",
-        "### pass@K vs pass^K\n",
-        "\n",
-        "- **pass@K**: At least one of K responses is correct. This measures whether an agent *can* produce a correct answer with multiple attempts.\n",
-        "- **pass^K**: All K responses are correct. This measures consistency and reliability.\n",
-        "\n",
-        "### Tool Correctness\n",
-        "\n",
-        "Tool correctness evaluates four aspects:\n",
-        "\n",
-        "1. **Selection (25%)**: Did the agent choose the right tools?\n",
-        "2. **Parameters (25%)**: Did the agent pass correct parameters?\n",
-        "3. **Sequence (25%)**: Did the agent use tools in the correct order? (only if `tool_sequence_matters=true`)\n",
-        "4. **Utilization (25%)**: Did the agent use tool results in the final answer?\n",
-        "\n",
-        "The overall score is a weighted average. By default, all weights are 0.25, but you can customize them.\n",
-        "\n",
-        "### Use Cases\n",
-        "\n",
-        "- **Agent Reliability**: Compare pass@K vs pass^K to understand if your agent is consistent\n",
-        "- **Tool Usage**: Identify which aspects of tool usage need improvement\n",
-        "- **Model Comparison**: Compare different models or prompting strategies\n",
-        "- **Quality Benchmarking**: Track agent performance over time"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "custom-header",
-      "metadata": {},
-      "source": [
-        "## Custom Thresholds and Weights\n",
-        "\n",
-        "You can customize thresholds and tool correctness weights:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "id": "custom",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "# Run with custom settings\n",
-        "custom_metrics = Agentic.run(\n",
-        "    AgenticRetriever,\n",
-        "    model=judge_model,\n",
-        "    threshold=0.8,  # Stricter answer threshold\n",
-        "    tool_threshold=0.7,  # More lenient tool threshold\n",
-        "    tool_weights={\n",
-        "        \"selection\": 0.4,  # Emphasize tool selection\n",
-        "        \"parameters\": 0.3,  # Emphasize parameters\n",
-        "        \"sequence\": 0.2,\n",
-        "        \"utilization\": 0.1,\n",
-        "    },\n",
-        "    verbose=False,\n",
-        ")\n",
-        "\n",
-        "print(f\"Custom evaluation with threshold=0.8:\")\n",
-        "for m in custom_metrics:\n",
-        "    print(f\"  {m.qa_id}: pass@{m.k}={m.pass_at_k}, pass^{m.k}={m.pass_pow_k}\")"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11.0"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Agentic Metric Example\n",
+    "\n",
+    "This notebook demonstrates how to use the **Agentic** metric from Fair Forge to evaluate AI agent responses with pass@K and tool correctness.\n",
+    "\n",
+    "The metric evaluates:\n",
+    "- **pass@K**: At least one of K responses is correct (score >= threshold)\n",
+    "- **pass^K**: All K responses are correct\n",
+    "- **Tool Correctness**: Proper tool usage across 4 dimensions:\n",
+    "  - Selection (25%): Were the correct tools chosen?\n",
+    "  - Parameters (25%): Were correct parameters passed?\n",
+    "  - Sequence (25%): Were tools used in the correct order?\n",
+    "  - Utilization (25%): Were tool results used in the final answer?"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "install-header",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "First, install Fair Forge with agentic support and required dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 install alquimia-fair-forge==1.2.0b1 langchain-groq"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-header",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Import required modules and configure your API key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Add examples directory to path for local imports\n",
+    "sys.path.insert(0, str(Path(\"../..\").resolve()))\n",
+    "\n",
+    "from langchain_groq import ChatGroq\n",
+    "\n",
+    "from fair_forge import Retriever\n",
+    "from fair_forge.metrics.agentic import Agentic\n",
+    "from fair_forge.schemas import Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "api-key",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "\n",
+    "GROQ_API_KEY = getpass.getpass(\"Enter your Groq API key: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "retriever-header",
+   "metadata": {},
+   "source": [
+    "## Create an Agentic Retriever\n",
+    "\n",
+    "The Agentic metric requires **K datasets with the same qa_id** but different assistant_id values. Each dataset represents one agent response.\n",
+    "\n",
+    "In our example, we have K=3 responses for each question."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "retriever",
+   "metadata": {},
+   "outputs": [],
+   "source": "class AgenticRetriever(Retriever):\n    \"\"\"Retriever that loads K agent responses for the same questions.\"\"\"\n\n    def load_dataset(self) -> list[Dataset]:\n        dataset_path = Path(\"dataset_agentic.json\")\n        datasets = []\n        with open(dataset_path) as infile:\n            for dataset in json.load(infile):\n                datasets.append(Dataset.model_validate(dataset))\n        return datasets"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "preview-header",
+   "metadata": {},
+   "source": [
+    "## Preview the Dataset\n",
+    "\n",
+    "Let's see the structure of our test dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preview",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retriever = AgenticRetriever()\n",
+    "datasets = retriever.load_dataset()\n",
+    "\n",
+    "print(f\"Number of agent responses (K): {len(datasets)}\")\n",
+    "print(f\"\\nAgent IDs: {[ds.assistant_id for ds in datasets]}\")\n",
+    "print(f\"Number of questions: {len(datasets[0].conversation)}\")\n",
+    "\n",
+    "print(\"\\nQuestions (qa_ids):\")\n",
+    "for batch in datasets[0].conversation:\n",
+    "    print(f\"  - {batch.qa_id}: {batch.query}\")\n",
+    "\n",
+    "print(\"\\nSample responses for each question:\")\n",
+    "for ds in datasets:\n",
+    "    print(f\"\\n{'='*70}\")\n",
+    "    print(f\"{ds.assistant_id}:\")\n",
+    "    print('='*70)\n",
+    "\n",
+    "    for batch in ds.conversation:\n",
+    "        print(f\"\\n  📝 {batch.qa_id}:\")\n",
+    "        print(f\"     Query: {batch.query}\")\n",
+    "        print(f\"     Answer: {batch.assistant[:100]}{'...' if len(batch.assistant) > 100 else ''}\")\n",
+    "\n",
+    "        # Verificación segura de tools\n",
+    "        tools_used = batch.agentic.get('tools_used', []) if batch.agentic else []\n",
+    "        print(f\"     Tools used: {len(tools_used)} tool(s)\")\n",
+    "\n",
+    "        if tools_used:\n",
+    "            for tool in tools_used:\n",
+    "                params_str = ', '.join(f\"{k}={v}\" for k, v in tool['parameters'].items())\n",
+    "                print(f\"       🔧 {tool['tool_name']}({params_str})\")\n",
+    "                if 'result' in tool:\n",
+    "                    print(f\"          → Result: {tool['result']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "model-header",
+   "metadata": {},
+   "source": [
+    "## Initialize the Judge Model\n",
+    "\n",
+    "The Agentic metric uses an LLM judge to evaluate answer correctness."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "model",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "judge_model = ChatGroq(\n",
+    "    model=\"llama-3.3-70b-versatile\",\n",
+    "    api_key=GROQ_API_KEY,\n",
+    "    temperature=0.0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-header",
+   "metadata": {},
+   "source": [
+    "## Run the Agentic Metric\n",
+    "\n",
+    "The metric will evaluate:\n",
+    "1. Answer correctness for each of K responses\n",
+    "2. pass@K: At least one response is correct\n",
+    "3. pass^K: All responses are correct\n",
+    "4. Tool correctness: Proper tool usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metrics = Agentic.run(\n",
+    "    AgenticRetriever,\n",
+    "    model=judge_model,\n",
+    "    threshold=0.7,\n",
+    "    tool_threshold=1.0,\n",
+    "    use_structured_output=True,\n",
+    "    verbose=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "analyze-header",
+   "metadata": {},
+   "source": [
+    "## Analyze Results\n",
+    "\n",
+    "Let's examine the evaluation results for each question."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "analyze",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Total metrics: {len(metrics)}\\n\")\n",
+    "print(\"=\" * 70)\n",
+    "\n",
+    "for metric in metrics:\n",
+    "    print(f\"\\nQuestion ID: {metric.qa_id}\")\n",
+    "    print(f\"K (responses): {metric.k}\")\n",
+    "    print(f\"Threshold: {metric.threshold}\")\n",
+    "    print(f\"\\nCorrectness scores: {[f'{s:.2f}' for s in metric.correctness_scores]}\")\n",
+    "    print(f\"Correct indices: {metric.correct_indices}\")\n",
+    "    print(f\"\\npass@{metric.k}: {metric.pass_at_k} ({'✓' if metric.pass_at_k else '✗'})\")\n",
+    "    print(f\"pass^{metric.k}: {metric.pass_pow_k} ({'✓' if metric.pass_pow_k else '✗'})\")\n",
+    "    \n",
+    "    if metric.tool_correctness_scores:\n",
+    "        print(f\"\\nTool Correctness Scores (K={metric.k}):\")\n",
+    "        for i, tc in enumerate(metric.tool_correctness_scores, 1):\n",
+    "            if tc:\n",
+    "                print(f\"\\n  Response {i}:\")\n",
+    "                print(f\"    Selection:    {tc.tool_selection_correct:.2f}\")\n",
+    "                print(f\"    Parameters:   {tc.parameter_accuracy:.2f}\")\n",
+    "                print(f\"    Sequence:     {tc.sequence_correct:.2f}\")\n",
+    "                print(f\"    Utilization:  {tc.result_utilization:.2f}\")\n",
+    "                print(f\"    Overall:      {tc.overall_correctness:.2f} ({'✓' if tc.is_correct else '✗'})\")\n",
+    "            else:\n",
+    "                print(f\"\\n  Response {i}: No tools used\")\n",
+    "    \n",
+    "    print(\"\\n\" + \"-\" * 70)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "summary-header",
+   "metadata": {},
+   "source": [
+    "## Summary Statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "summary",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pass_at_k_count = sum(1 for m in metrics if m.pass_at_k)\n",
+    "pass_pow_k_count = sum(1 for m in metrics if m.pass_pow_k)\n",
+    "tool_correct_count = sum(\n",
+    "      1 for m in metrics\n",
+    "      for tc in m.tool_correctness_scores\n",
+    "      if tc and tc.is_correct\n",
+    "  )\n",
+    "\n",
+    "print(\"Summary Statistics:\")\n",
+    "print(f\"Total questions evaluated: {len(metrics)}\")\n",
+    "print(f\"\\npass@K success rate: {pass_at_k_count}/{len(metrics)} ({pass_at_k_count/len(metrics)*100:.1f}%)\")\n",
+    "print(f\"pass^K success rate: {pass_pow_k_count}/{len(metrics)} ({pass_pow_k_count/len(metrics)*100:.1f}%)\")\n",
+    "print(f\"Tool correctness rate: {tool_correct_count}/{len(metrics)} ({tool_correct_count/len(metrics)*100:.1f}%)\")\n",
+    "\n",
+    "avg_score = sum(sum(m.correctness_scores) for m in metrics) / sum(len(m.correctness_scores) for m in metrics)\n",
+    "print(f\"\\nAverage correctness score: {avg_score:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "viz-header",
+   "metadata": {},
+   "source": [
+    "## Visualize Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "viz",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(14, 10))\n",
+    "\n",
+    "# Plot 1: Correctness scores by question\n",
+    "ax1 = axes[0, 0]\n",
+    "qa_ids = [m.qa_id for m in metrics]\n",
+    "x_pos = np.arange(len(qa_ids))\n",
+    "\n",
+    "for i in range(metrics[0].k):\n",
+    "    scores = [m.correctness_scores[i] if i < len(m.correctness_scores) else 0 for m in metrics]\n",
+    "    ax1.bar(x_pos + i*0.25, scores, 0.25, label=f'Response {i+1}', alpha=0.8)\n",
+    "\n",
+    "ax1.axhline(y=0.7, color='r', linestyle='--', label='Threshold')\n",
+    "ax1.set_xlabel('Question')\n",
+    "ax1.set_ylabel('Correctness Score')\n",
+    "ax1.set_title('Correctness Scores by Question and Response')\n",
+    "ax1.set_xticks(x_pos + 0.25)\n",
+    "ax1.set_xticklabels([qa.replace('_', '\\n') for qa in qa_ids], rotation=0, ha='center')\n",
+    "ax1.legend()\n",
+    "ax1.grid(axis='y', alpha=0.3)\n",
+    "\n",
+    "# Plot 2: pass@K vs pass^K\n",
+    "ax2 = axes[0, 1]\n",
+    "pass_at_k = [m.pass_at_k for m in metrics]\n",
+    "pass_pow_k = [m.pass_pow_k for m in metrics]\n",
+    "x = np.arange(len(qa_ids))\n",
+    "width = 0.35\n",
+    "\n",
+    "ax2.bar(x - width/2, pass_at_k, width, label='pass@K', color='green', alpha=0.7)\n",
+    "ax2.bar(x + width/2, pass_pow_k, width, label='pass^K', color='blue', alpha=0.7)\n",
+    "ax2.set_xlabel('Question')\n",
+    "ax2.set_ylabel('Result (True/False)')\n",
+    "ax2.set_title('pass@K vs pass^K by Question')\n",
+    "ax2.set_xticks(x)\n",
+    "ax2.set_xticklabels([qa.replace('_', '\\n') for qa in qa_ids], rotation=0, ha='center')\n",
+    "ax2.set_yticks([0, 1])\n",
+    "ax2.set_yticklabels(['False', 'True'])\n",
+    "ax2.legend()\n",
+    "ax2.grid(axis='y', alpha=0.3)\n",
+    "\n",
+    "# Plot 3: Tool correctness components\n",
+    "ax3 = axes[1, 0]\n",
+    "components = ['Selection', 'Parameters', 'Sequence', 'Utilization']\n",
+    "x_pos = np.arange(len(components))\n",
+    "\n",
+    "for i, m in enumerate(metrics):\n",
+    "    if m.tool_correctness_scores:\n",
+    "        tc = m.tool_correctness_scores[0]  # Assuming we're interested in the first response for each metric\n",
+    "        scores = [\n",
+    "            tc.tool_selection_correct,\n",
+    "            tc.parameter_accuracy,\n",
+    "            tc.sequence_correct,\n",
+    "            tc.result_utilization\n",
+    "        ]\n",
+    "        ax3.plot(x_pos, scores, marker='o', label=m.qa_id, linewidth=2)\n",
+    "\n",
+    "ax3.axhline(y=0.75, color='r', linestyle='--', label='Threshold', alpha=0.5)\n",
+    "ax3.set_xlabel('Component')\n",
+    "ax3.set_ylabel('Score')\n",
+    "ax3.set_title('Tool Correctness Components by Question')\n",
+    "ax3.set_xticks(x_pos)\n",
+    "ax3.set_xticklabels(components)\n",
+    "ax3.legend()\n",
+    "ax3.grid(True, alpha=0.3)\n",
+    "ax3.set_ylim(0, 1.05)\n",
+    "\n",
+    "# Plot 4: Overall metrics summary\n",
+    "ax4 = axes[1, 1]\n",
+    "metrics_data = [\n",
+    "    pass_at_k_count / len(metrics),\n",
+    "    pass_pow_k_count / len(metrics),\n",
+    "    tool_correct_count / len(metrics),\n",
+    "    avg_score\n",
+    "]\n",
+    "metric_names = ['pass@K\\nRate', 'pass^K\\nRate', 'Tool\\nCorrect Rate', 'Avg\\nScore']\n",
+    "colors = ['green', 'blue', 'orange', 'purple']\n",
+    "\n",
+    "bars = ax4.bar(metric_names, metrics_data, color=colors, alpha=0.7)\n",
+    "ax4.set_ylabel('Rate / Score')\n",
+    "ax4.set_title('Overall Metrics Summary')\n",
+    "ax4.set_ylim(0, 1.05)\n",
+    "ax4.grid(axis='y', alpha=0.3)\n",
+    "\n",
+    "for bar, value in zip(bars, metrics_data):\n",
+    "    height = bar.get_height()\n",
+    "    ax4.text(bar.get_x() + bar.get_width()/2., height + 0.02,\n",
+    "             f'{value:.2f}', ha='center', va='bottom', fontweight='bold')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "understanding",
+   "metadata": {},
+   "source": [
+    "## Understanding the Results\n",
+    "\n",
+    "### pass@K vs pass^K\n",
+    "\n",
+    "- **pass@K**: At least one of K responses is correct. This measures whether an agent *can* produce a correct answer with multiple attempts.\n",
+    "- **pass^K**: All K responses are correct. This measures consistency and reliability.\n",
+    "\n",
+    "### Tool Correctness\n",
+    "\n",
+    "Tool correctness evaluates four aspects:\n",
+    "\n",
+    "1. **Selection (25%)**: Did the agent choose the right tools?\n",
+    "2. **Parameters (25%)**: Did the agent pass correct parameters?\n",
+    "3. **Sequence (25%)**: Did the agent use tools in the correct order? (only if `tool_sequence_matters=true`)\n",
+    "4. **Utilization (25%)**: Did the agent use tool results in the final answer?\n",
+    "\n",
+    "The overall score is a weighted average. By default, all weights are 0.25, but you can customize them.\n",
+    "\n",
+    "### Use Cases\n",
+    "\n",
+    "- **Agent Reliability**: Compare pass@K vs pass^K to understand if your agent is consistent\n",
+    "- **Tool Usage**: Identify which aspects of tool usage need improvement\n",
+    "- **Model Comparison**: Compare different models or prompting strategies\n",
+    "- **Quality Benchmarking**: Track agent performance over time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "custom-header",
+   "metadata": {},
+   "source": [
+    "## Custom Thresholds and Weights\n",
+    "\n",
+    "You can customize thresholds and tool correctness weights:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "custom",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run with custom settings\n",
+    "custom_metrics = Agentic.run(\n",
+    "    AgenticRetriever,\n",
+    "    model=judge_model,\n",
+    "    threshold=0.8,  # Stricter answer threshold\n",
+    "    tool_threshold=0.7,  # More lenient tool threshold\n",
+    "    tool_weights={\n",
+    "        \"selection\": 0.4,  # Emphasize tool selection\n",
+    "        \"parameters\": 0.3,  # Emphasize parameters\n",
+    "        \"sequence\": 0.2,\n",
+    "        \"utilization\": 0.1,\n",
+    "    },\n",
+    "    verbose=False,\n",
+    ")\n",
+    "\n",
+    "print(f\"Custom evaluation with threshold=0.8:\")\n",
+    "for m in custom_metrics:\n",
+    "    print(f\"  {m.qa_id}: pass@{m.k}={m.pass_at_k}, pass^{m.k}={m.pass_pow_k}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "alquimia-fair-forge",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/fair_forge/schemas/agentic.py
+++ b/fair_forge/schemas/agentic.py
@@ -39,4 +39,4 @@ class AgenticMetric(BaseMetric):
     pass_at_k: bool
     pass_pow_k: bool
     correct_indices: list[int]
-    tool_correctness: ToolCorrectnessScore | None = None
+    tool_correctness_scores: list[ToolCorrectnessScore | None] = []

--- a/tests/metrics/test_agentic.py
+++ b/tests/metrics/test_agentic.py
@@ -26,7 +26,7 @@ class TestAgenticMetric:
         assert agentic.bos_json_clause == "```json"
         assert agentic.eos_json_clause == "```"
         assert agentic.threshold == 0.7
-        assert agentic.tool_threshold == 0.75
+        assert agentic.tool_threshold == 1.0
         assert agentic.tool_weights == {
             "selection": 0.25,
             "parameters": 0.25,
@@ -365,10 +365,11 @@ class TestAgenticMetric:
 
         metric = metrics[0]
 
-        assert metric.tool_correctness is not None
-        assert isinstance(metric.tool_correctness, ToolCorrectnessScore)
-        assert metric.tool_correctness.overall_correctness >= 0.0
-        assert metric.tool_correctness.overall_correctness <= 1.0
+        assert metric.tool_correctness_scores is not None
+        assert len(metric.tool_correctness_scores) > 0
+        assert isinstance(metric.tool_correctness_scores[0], ToolCorrectnessScore)
+        assert metric.tool_correctness_scores[0].overall_correctness >= 0.0
+        assert metric.tool_correctness_scores[0].overall_correctness <= 1.0
 
     @patch("fair_forge.metrics.agentic.Judge")
     def test_answer_judge_returns_none(self, mock_judge_class, mock_model):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -176,7 +176,7 @@ wheels = [
 
 [[package]]
 name = "alquimia-fair-forge"
-version = "1.1.0"
+version = "1.2.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Fixes tool correctness evaluation to assess all K responses instead of just the first one.

**Breaking Change:** AgenticMetric.tool_correctness → tool_correctness_scores (list)
**Threshold:** Default changed from 0.75 to 1.0 (stricter)

See commit message for full details.
