### PR TITLE
feat: statistical mode

### DIFF
--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "18"
 
       - name: Install Mintlify CLI
         run: npm install -g mintlify

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install Mintlify CLI
-        run: npm install -g mintlify
+        run: npm install -g mintlify@4.0.5
 
       - name: Validate docs
         run: mintlify validate

--- a/docs/core-concepts/dataset-batch.mdx
+++ b/docs/core-concepts/dataset-batch.mdx
@@ -88,6 +88,7 @@ batch = Batch(
 | `agentic` | `dict \| None` | No | Metadata about the interaction |
 | `ground_truth_agentic` | `dict \| None` | No | Expected metadata |
 | `logprobs` | `dict \| None` | No | Log probabilities from the model |
+| `weight` | `float \| None` | No | Relative importance when aggregating session-level scores |
 
 ### Field Details
 
@@ -154,6 +155,28 @@ batch = Batch(
         "token_logprobs": [-0.1, -0.05, -0.02, -0.01],
     }
     ```
+  </Accordion>
+
+  <Accordion title="weight">
+    Optional relative importance of this interaction when metrics aggregate scores at session level (Conversational, Context, Regulatory). Controls how much each QA pair contributes to the session mean.
+
+    ```python
+    # All provided and sum to 1 → used as-is
+    Batch(qa_id="q1", ..., weight=0.5),
+    Batch(qa_id="q2", ..., weight=0.3),
+    Batch(qa_id="q3", ..., weight=0.2),
+
+    # Some provided → remaining weight split equally among unweighted
+    Batch(qa_id="q1", ..., weight=0.6),
+    Batch(qa_id="q2", ...),   # gets 0.2
+    Batch(qa_id="q3", ...),   # gets 0.2
+
+    # None provided → equal weights (1/n each)
+    Batch(qa_id="q1", ...),
+    Batch(qa_id="q2", ...),
+    ```
+
+    If all weights are provided but do not sum to 1.0, a warning is emitted and equal weights are applied instead.
   </Accordion>
 </AccordionGroup>
 
@@ -245,14 +268,16 @@ print(batch.observation)  # None
 
 Different metrics use different fields:
 
-| Metric | Key Fields Used |
-|--------|----------------|
-| **Toxicity** | `assistant`, `session_id`, `assistant_id` |
-| **Bias** | `query`, `assistant`, `context` |
-| **Context** | `query`, `assistant`, `context`, `ground_truth_assistant` |
-| **Conversational** | `query`, `assistant`, `observation`, `ground_truth_assistant` |
-| **Humanity** | `assistant`, `ground_truth_assistant` |
-| **BestOf** | `query`, `assistant` (across multiple datasets) |
+| Metric | Key Fields Used | Output Granularity |
+|--------|----------------|-------------------|
+| **Toxicity** | `assistant`, `session_id`, `assistant_id` | Global stream |
+| **Bias** | `query`, `assistant`, `context` | Per session |
+| **Context** | `query`, `assistant`, `context`, `ground_truth_assistant`, `weight` | Per session |
+| **Conversational** | `query`, `assistant`, `observation`, `ground_truth_assistant`, `weight` | Per session |
+| **Regulatory** | `query`, `assistant`, `weight` | Per session |
+| **Humanity** | `assistant`, `ground_truth_assistant` | Per interaction |
+| **BestOf** | `query`, `assistant` | Per block |
+| **Agentic** | `query`, `assistant`, `ground_truth_assistant`, `agentic`, `ground_truth_agentic` | Per conversation |
 
 ## Best Practices
 

--- a/docs/core-concepts/statistical-modes.mdx
+++ b/docs/core-concepts/statistical-modes.mdx
@@ -1,307 +1,314 @@
 ---
 title: Statistical Modes
-description: Choose between Frequentist and Bayesian statistical approaches
+description: Pluggable Frequentist and Bayesian statistical strategies across Fair Forge metrics
 ---
 
 # Statistical Modes
 
-Fair Forge supports two statistical approaches for computing metrics: **Frequentist** and **Bayesian**. This is particularly relevant for the Toxicity metric.
+Fair Forge metrics that perform **statistical aggregation** accept a pluggable `statistical_mode` parameter. The same computation — estimating a rate, measuring distribution divergence, aggregating sub-metrics — can be performed either as a **point estimate** (Frequentist) or as a **full posterior distribution with credible intervals** (Bayesian).
 
-## Overview
+## Which Metrics Support Statistical Modes
 
-| Mode | Returns | Best For |
-|------|---------|----------|
-| **Frequentist** | Point estimates (single values) | Quick analysis, large datasets |
-| **Bayesian** | Full distributions with credible intervals | Uncertainty quantification, small datasets |
+| Metric | Primitives Used | What Gets a CI in Bayesian Mode |
+|--------|----------------|----------------------------------|
+| **Toxicity** | All four | DR, ASB, DTO, DIDT |
+| **Bias** | `rate_estimation` | Bias rate per protected attribute |
+| **Agentic** | `rate_estimation` | pass@K and pass^K |
+
+## The Four Primitives
+
+`StatisticalMode` defines four abstract primitives. Every metric composes these to compute its final result — it never contains its own statistical logic.
+
+### `rate_estimation(successes, trials)`
+
+Estimates a proportion from count data.
+
+| Mode | Returns | How |
+|------|---------|-----|
+| Frequentist | `float` | `successes / trials` |
+| Bayesian | `dict` with `mean`, `ci_low`, `ci_high`, `samples` | Beta-Binomial posterior: `Beta(1 + successes, 1 + trials - successes)` |
+
+**Used by:** Bias (bias rate per attribute), Toxicity (toxicity rate per group), Agentic (success rate p = c/n)
+
+### `distribution_divergence(observed, reference)`
+
+Measures how far an observed distribution is from a reference.
+
+| Mode | Returns | How |
+|------|---------|-----|
+| Frequentist | `float` | Total variation distance: `0.5 * Σ|p_i - q_i|` |
+| Bayesian | `dict` | Dirichlet posterior over `p`, divergence computed per MC sample |
+
+**Used by:** Toxicity (DR — demographic representation)
+
+### `aggregate_metrics(metrics, weights)`
+
+Combines multiple named sub-metrics into one weighted score.
+
+| Mode | Returns | How |
+|------|---------|-----|
+| Frequentist | `float` | Normalized weighted sum |
+| Bayesian | `dict` | Weighted sum applied per MC sample, then summarized |
+
+**Used by:** Toxicity (DIDT = weighted average of DR, DTO, ASB)
+
+### `dispersion_metric(values, center)`
+
+Measures how spread out a set of values is around their center.
+
+| Mode | Returns | How |
+|------|---------|-----|
+| Frequentist | `float` | Mean absolute deviation (MAD) |
+| Bayesian | `dict` | MAD computed per MC sample, then summarized |
+
+**Used by:** Toxicity (DTO — toxicity rate dispersion across groups, ASB — sentiment dispersion across groups)
+
+---
 
 ## Frequentist Mode
 
-The default mode returns simple point estimates.
+The default mode. Returns a single float for every primitive — no uncertainty, no samples.
 
 ```python
+from fair_forge.statistical import FrequentistMode
+
+mode = FrequentistMode()
+mode.get_result_type()  # "point_estimate"
+```
+
+### Usage
+
+```python
+from fair_forge.metrics.bias import Bias
+from fair_forge.metrics.agentic import Agentic
 from fair_forge.metrics.toxicity import Toxicity
 from fair_forge.statistical import FrequentistMode
 
-metrics = Toxicity.run(
-    MyRetriever,
-    group_prototypes=group_prototypes,
-    statistical_mode=FrequentistMode(),  # Default
-)
+# Bias
+metrics = Bias.run(MyRetriever, guardian=LLamaGuard, config=cfg)
+# metric.attribute_rates[0].rate       → 0.12  (float)
+# metric.attribute_rates[0].ci_low     → None
+# metric.attribute_rates[0].ci_high    → None
 
-# Access results
-for metric in metrics:
-    gp = metric.group_profiling
-    if gp and gp.frequentist:
-        print(f"DR: {gp.frequentist.DR}")    # Single float
-        print(f"ASB: {gp.frequentist.ASB}")  # Single float
-        print(f"DTO: {gp.frequentist.DTO}")  # Single float
-        print(f"DIDT: {gp.frequentist.DIDT}") # Single float
+# Agentic
+metrics = Agentic.run(MyRetriever, model=judge, k=3)
+# metric.pass_at_k                     → 0.973  (float)
+# metric.pass_at_k_ci_low              → None
+# metric.pass_at_k_ci_high             → None
+
+# Toxicity
+metrics = Toxicity.run(MyRetriever, group_prototypes=prototypes)
+# metric.group_profiling.frequentist.DIDT  → 0.124  (float)
+# metric.group_profiling.bayesian          → None
 ```
-
-### Frequentist Methods
-
-| Method | Description |
-|--------|-------------|
-| `distribution_divergence()` | Total variation distance |
-| `rate_estimation()` | Simple proportion (successes/trials) |
-| `aggregate_metrics()` | Weighted sum |
-| `dispersion_metric()` | Mean absolute deviation |
 
 ### When to Use
 
-- Large datasets (>100 samples)
-- Quick preliminary analysis
-- When point estimates are sufficient
+- Large datasets (100+ samples) where point estimates are reliable
 - Production systems where speed matters
+- Quick exploratory analysis
+
+---
 
 ## Bayesian Mode
 
-Returns full posterior distributions with uncertainty quantification.
+Returns full posterior distributions. Every primitive produces `mean`, `ci_low`, `ci_high`, and raw `samples` (MC draws). The CI width reflects how much uncertainty remains given the observed data.
 
 ```python
-from fair_forge.metrics.toxicity import Toxicity
 from fair_forge.statistical import BayesianMode
 
-bayesian = BayesianMode(
-    mc_samples=5000,      # Monte Carlo samples
-    ci_level=0.95,        # 95% credible intervals
-    dirichlet_prior=1.0,  # Dirichlet prior for distributions
-    beta_prior_a=1.0,     # Beta prior alpha
-    beta_prior_b=1.0,     # Beta prior beta
+mode = BayesianMode(
+    mc_samples=5000,      # Number of Monte Carlo draws
+    ci_level=0.95,        # Credible interval level
+    dirichlet_prior=1.0,  # Prior for distribution_divergence (uniform)
+    beta_prior_a=1.0,     # Prior for rate_estimation (uninformative)
+    beta_prior_b=1.0,
     rng_seed=42,          # For reproducibility
 )
-
-metrics = Toxicity.run(
-    MyRetriever,
-    group_prototypes=group_prototypes,
-    statistical_mode=bayesian,
-)
-
-# Access results
-for metric in metrics:
-    gp = metric.group_profiling
-    if gp and gp.bayesian:
-        summary = gp.bayesian.summary
-
-        for component in ['DR', 'ASB', 'DTO', 'DIDT']:
-            s = summary[component]
-            print(f"{component}:")
-            print(f"  Mean: {s.mean:.4f}")
-            print(f"  95% CI: [{s.ci_low:.4f}, {s.ci_high:.4f}]")
+mode.get_result_type()  # "distribution"
 ```
 
 ### BayesianMode Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `mc_samples` | `int` | `5000` | Number of Monte Carlo samples |
-| `ci_level` | `float` | `0.95` | Credible interval level (0-1) |
-| `dirichlet_prior` | `float` | `1.0` | Dirichlet prior concentration |
-| `beta_prior_a` | `float` | `1.0` | Beta distribution alpha parameter |
-| `beta_prior_b` | `float` | `1.0` | Beta distribution beta parameter |
-| `rng_seed` | `int \| None` | `42` | Random seed for reproducibility |
+| `mc_samples` | `int` | `5000` | Monte Carlo samples for posterior approximation |
+| `ci_level` | `float` | `0.95` | Credible interval level (e.g. 0.95 for 95% CI) |
+| `dirichlet_prior` | `float` | `1.0` | Symmetric Dirichlet prior for `distribution_divergence` |
+| `beta_prior_a` | `float` | `1.0` | Beta prior α for `rate_estimation` |
+| `beta_prior_b` | `float` | `1.0` | Beta prior β for `rate_estimation` |
+| `rng_seed` | `int \| None` | `42` | Seed for reproducibility (`None` = random) |
 
-### Bayesian Output Structure
+### Usage
 
-```python
-# The BayesianGroupProfiling structure
-gp.bayesian.mc_samples      # Number of samples used
-gp.bayesian.ci_level        # Credible interval level
-gp.bayesian.priors          # Prior parameters used
-gp.bayesian.summary         # Dict of component summaries
+<CodeGroup>
+```python Bias
+from fair_forge.metrics.bias import Bias
+from fair_forge.statistical import BayesianMode
 
-# Each component summary contains:
-summary['DIDT'].mean        # Posterior mean
-summary['DIDT'].ci_low      # Lower credible bound
-summary['DIDT'].ci_high     # Upper credible bound
-summary['DIDT'].samples     # Raw posterior samples (optional)
-```
-
-### When to Use
-
-- Small datasets (fewer than 100 samples)
-- When uncertainty quantification is important
-- Research and scientific applications
-- When making decisions based on confidence levels
-
-## Comparison Example
-
-```python
-from fair_forge.metrics.toxicity import Toxicity
-from fair_forge.statistical import FrequentistMode, BayesianMode
-
-group_prototypes = {
-    "gender": ["women", "men", "female", "male"],
-    "race": ["Asian", "African", "European", "Hispanic"],
-}
-
-# Run with Frequentist mode
-freq_metrics = Toxicity.run(
+metrics = Bias.run(
     MyRetriever,
-    group_prototypes=group_prototypes,
-    statistical_mode=FrequentistMode(),
-)
-
-# Run with Bayesian mode
-bayes_metrics = Toxicity.run(
-    MyRetriever,
-    group_prototypes=group_prototypes,
+    guardian=LLamaGuard,
+    config=cfg,
     statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
 )
 
-# Compare results
-print("Comparison: Frequentist vs Bayesian")
-print("=" * 60)
+for rate in metrics[0].attribute_rates:
+    print(f"{rate.protected_attribute}:")
+    print(f"  bias rate = {rate.rate:.3f}  [{rate.ci_low:.3f}, {rate.ci_high:.3f}]")
+```
 
-freq_gp = freq_metrics[0].group_profiling
-bayes_gp = bayes_metrics[0].group_profiling
+```python Agentic
+from fair_forge.metrics.agentic import Agentic
+from fair_forge.statistical import BayesianMode
 
+metrics = Agentic.run(
+    MyRetriever,
+    model=judge,
+    k=3,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
+)
+
+for metric in metrics:
+    print(f"pass@3 = {metric.pass_at_k:.3f}  [{metric.pass_at_k_ci_low:.3f}, {metric.pass_at_k_ci_high:.3f}]")
+    print(f"pass^3 = {metric.pass_pow_k:.3f}  [{metric.pass_pow_k_ci_low:.3f}, {metric.pass_pow_k_ci_high:.3f}]")
+```
+
+```python Toxicity
+from fair_forge.metrics.toxicity import Toxicity
+from fair_forge.statistical import BayesianMode
+
+metrics = Toxicity.run(
+    MyRetriever,
+    group_prototypes=prototypes,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
+)
+
+gp = metrics[0].group_profiling
 for component in ['DR', 'ASB', 'DTO', 'DIDT']:
-    freq_val = getattr(freq_gp.frequentist, component)
-    bayes_summary = bayes_gp.bayesian.summary[component]
-
-    print(f"\n{component}:")
-    print(f"  Frequentist: {freq_val:.4f}")
-    print(f"  Bayesian:    {bayes_summary.mean:.4f} [{bayes_summary.ci_low:.4f}, {bayes_summary.ci_high:.4f}]")
+    s = gp.bayesian.summary[component]
+    print(f"{component}: {s.mean:.4f}  [{s.ci_low:.4f}, {s.ci_high:.4f}]")
 ```
+</CodeGroup>
 
-**Output:**
-```
-Comparison: Frequentist vs Bayesian
-============================================================
+### When to Use
 
-DR:
-  Frequentist: 0.5000
-  Bayesian:    0.1862 [0.0084, 0.4355]
+- Small datasets (fewer than 50–100 samples) where point estimates can be misleading
+- Auditing and compliance contexts where uncertainty must be communicated
+- Research applications requiring rigorous statistical reporting
+- Any scenario where a wide CI should trigger a "collect more data" decision
 
-ASB:
-  Frequentist: 0.0000
-  Bayesian:    0.0000 [0.0000, 0.0000]
+---
 
-DTO:
-  Frequentist: 0.5000
-  Bayesian:    0.3376 [0.1622, 0.4709]
-
-DIDT:
-  Frequentist: 0.3333
-  Bayesian:    0.1746 [0.0853, 0.2728]
-```
-
-## Understanding the Difference
-
-The key difference is in how they handle uncertainty:
+## How the CI Width Tells You When to Trust a Result
 
 <Tabs>
   <Tab title="Small Sample (n=10)">
-    With small samples, Frequentist estimates can be misleading:
-    - **Frequentist**: "DIDT = 0.50" (point estimate, no uncertainty)
-    - **Bayesian**: "DIDT = 0.35 [0.10, 0.65]" (wide interval shows uncertainty)
+    With 10 interactions and 3 flagged as biased:
 
-    The Bayesian approach acknowledges that with limited data, we can't be confident in a precise value.
+    - **Frequentist**: bias rate = 0.30 (single number, no context)
+    - **Bayesian**: bias rate = 0.30  **CI = [0.09, 0.57]**
+
+    The wide CI tells you the true rate could be anywhere from 9% to 57%. You cannot reliably conclude there is a bias problem — collect more data first.
   </Tab>
-  <Tab title="Large Sample (n=1000)">
-    With large samples, both converge:
-    - **Frequentist**: "DIDT = 0.32"
-    - **Bayesian**: "DIDT = 0.32 [0.29, 0.35]" (narrow interval)
+  <Tab title="Large Sample (n=200)">
+    With 200 interactions and 60 flagged:
 
-    More data leads to more confidence and narrower intervals.
+    - **Frequentist**: bias rate = 0.30
+    - **Bayesian**: bias rate = 0.30  **CI = [0.24, 0.36]**
+
+    The narrow CI confirms the estimate is reliable. A 30% bias rate is now a well-supported finding.
+  </Tab>
+  <Tab title="Agentic pass@K">
+    With 5 conversations, 4 fully correct, k=3:
+
+    - **Frequentist**: pass@3 = 0.992
+    - **Bayesian**: pass@3 = 0.960  **CI = [0.740, 0.999]**
+
+    The number sounds great — but the CI says it could be as low as 0.74. With only 5 conversations, the point estimate is not trustworthy.
   </Tab>
 </Tabs>
 
+---
+
 ## Priors in Bayesian Mode
 
-### Dirichlet Prior
+### Beta Prior (for `rate_estimation`)
 
-Used for distribution comparisons (e.g., group representation):
-
-```python
-BayesianMode(
-    dirichlet_prior=1.0,  # Uniform prior (no preference)
-)
-
-# Higher values = stronger prior toward uniformity
-BayesianMode(
-    dirichlet_prior=10.0,  # Strong prior toward uniform distribution
-)
-```
-
-### Beta Prior
-
-Used for rate estimation (e.g., toxicity rates):
+Used in Bias (bias rate) and Agentic (success rate). The `Beta(a, b)` prior expresses beliefs before seeing any data.
 
 ```python
-# Uninformative prior
-BayesianMode(
-    beta_prior_a=1.0,
-    beta_prior_b=1.0,
-)
+# Uninformative — no strong prior belief (default)
+BayesianMode(beta_prior_a=1.0, beta_prior_b=1.0)
 
-# Prior expecting low rates (pessimistic)
-BayesianMode(
-    beta_prior_a=1.0,
-    beta_prior_b=10.0,  # Expects ~10% rate
-)
+# Expect a low bias rate (optimistic about fairness)
+BayesianMode(beta_prior_a=1.0, beta_prior_b=9.0)  # Prior mean ≈ 0.10
 
-# Prior expecting high rates (optimistic)
-BayesianMode(
-    beta_prior_a=10.0,
-    beta_prior_b=1.0,  # Expects ~90% success rate
-)
+# Expect a high success rate (optimistic about agent performance)
+BayesianMode(beta_prior_a=9.0, beta_prior_b=1.0)  # Prior mean ≈ 0.90
 ```
+
+### Dirichlet Prior (for `distribution_divergence`)
+
+Used in Toxicity (DR — demographic representation). The `dirichlet_prior` scalar sets concentration across all categories.
+
+```python
+# Uniform prior — no preference for any group distribution (default)
+BayesianMode(dirichlet_prior=1.0)
+
+# Strong prior toward uniform distribution
+BayesianMode(dirichlet_prior=10.0)
+```
+
+---
 
 ## Custom Statistical Modes
 
-You can create custom statistical modes by implementing the `StatisticalMode` interface:
+Implement `StatisticalMode` to plug in your own strategy (e.g., Wilson score intervals, KL divergence):
 
 ```python
 from fair_forge.statistical.base import StatisticalMode
 from typing import Any
 
-class CustomMode(StatisticalMode):
-    def distribution_divergence(
-        self,
-        observed: dict,
-        reference: dict,
-        divergence_type: str = "kl"
-    ) -> float | dict[str, Any]:
-        # Your implementation
-        pass
+class WilsonMode(StatisticalMode):
+    """Frequentist mode using Wilson score intervals for rate estimation."""
 
-    def rate_estimation(
-        self,
-        successes: int,
-        trials: int
-    ) -> float | dict[str, Any]:
-        # Your implementation
-        pass
+    def rate_estimation(self, successes: int, trials: int) -> dict[str, Any]:
+        import scipy.stats as st
+        if trials == 0:
+            return {"mean": 0.0, "ci_low": 0.0, "ci_high": 0.0}
+        p = successes / trials
+        z = st.norm.ppf(0.975)
+        denom = 1 + z**2 / trials
+        center = (p + z**2 / (2 * trials)) / denom
+        margin = z * (p * (1 - p) / trials + z**2 / (4 * trials**2)) ** 0.5 / denom
+        return {"mean": center, "ci_low": center - margin, "ci_high": center + margin}
 
-    def aggregate_metrics(
-        self,
-        metrics: dict[str, float | dict],
-        weights: dict[str, float]
-    ) -> float | dict[str, Any]:
-        # Your implementation
-        pass
+    def distribution_divergence(self, observed, reference, divergence_type="total_variation"):
+        ...
 
-    def dispersion_metric(
-        self,
-        values: list[float],
-        center: float | None = None
-    ) -> float | dict[str, Any]:
-        # Your implementation
-        pass
+    def aggregate_metrics(self, metrics, weights):
+        ...
+
+    def dispersion_metric(self, values, center="mean"):
+        ...
 
     def get_result_type(self) -> str:
-        return "custom"  # or "point_estimate" or "distribution"
+        return "distribution"  # signals that CI fields will be populated
 ```
+
+---
 
 ## Next Steps
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Toxicity Metric" icon="flask" href="/metrics/toxicity">
-    See statistical modes in action
+    Statistical modes with group profiling (DR, DTO, ASB, DIDT)
   </Card>
-  <Card title="Metrics Overview" icon="chart-pie" href="/metrics/overview">
-    Explore all available metrics
+  <Card title="Bias Metric" icon="scale-balanced" href="/metrics/bias">
+    Beta-Binomial posteriors for protected attribute bias rates
+  </Card>
+  <Card title="Agentic Metric" icon="robot" href="/metrics/agentic">
+    Credible intervals for pass@K and pass^K
   </Card>
 </CardGroup>

--- a/docs/metrics/agentic.mdx
+++ b/docs/metrics/agentic.mdx
@@ -1,20 +1,18 @@
 ---
 title: Agentic
-description: Evaluate AI agent responses with pass@K metrics and tool correctness
+description: Evaluate AI agent responses with pass@K metrics, tool correctness, and pluggable statistical modes
 ---
 
 # Agentic Metric
 
-The Agentic metric evaluates AI agent performance by measuring complete conversation correctness. A conversation is correct only if ALL its interactions are correct.
+The Agentic metric evaluates AI agent performance by measuring complete conversation correctness. A conversation is correct only if **ALL** its interactions are correct. It supports pluggable **statistical modes** — frequentist returns point estimates for pass@K, Bayesian propagates the uncertainty in the estimated success rate through the pass@K formula to produce credible intervals.
 
 ## Overview
 
-This metric evaluates:
-
 - **Conversation Correctness**: A conversation is correct only if ALL interactions are correct
-- **pass@K**: Probability of ≥1 correct conversation when attempting k conversations (0.0-1.0)
-- **pass^K**: Probability of all k conversations being correct (0.0-1.0)
-- **Tool Correctness**: Evaluates tool selection, parameter accuracy, execution sequence, and result utilization **per interaction**
+- **pass@K**: Probability of ≥1 correct conversation when attempting k conversations (0.0–1.0)
+- **pass^K**: Probability of all k conversations being correct (0.0–1.0)
+- **Tool Correctness**: Evaluates tool selection, parameter accuracy, execution sequence, and result utilization per interaction
 
 ### Formulas
 
@@ -22,17 +20,14 @@ This metric evaluates:
 pass@k = 1 - (1 - p)^k   # Probability of ≥1 correct in k independent attempts
 pass^k = p^k              # Probability of all k attempts correct
 
-Where p = c/n (estimated success rate from evaluation)
+Where p = estimated success rate from evaluation
 ```
 
-Where:
-- **n** = total conversations evaluated
-- **c** = fully correct conversations (all interactions correct)
-- **p** = c/n, the agent's estimated success rate
-- **k** = number of attempts (user-configurable, not bounded by n)
+**Frequentist**: `p = c/n` — a point estimate
+**Bayesian**: `p` is a Beta-Binomial posterior distribution — the pass@K formula is applied across all posterior samples, yielding a credible interval for pass@K and pass^K
 
 <Note>
-**Important:** `k` is a **required** parameter in `Agentic.run()`. pass@K and pass^K are computed **per conversation** using the interactions of that conversation as the sample: `n = total_interactions`, `c = correct_interactions`. Each returned `AgenticMetric` exposes `pass_at_k`, `pass_pow_k`, and `k` as fields — no manual aggregation needed. The default `tool_threshold=1.0` requires perfect tool usage — lower it (e.g. `0.75`) to allow minor deviations.
+`k` is a **required** parameter. pass@K and pass^K are computed per conversation using `n = total_interactions` and `c = correct_interactions`. The default `tool_threshold=1.0` requires perfect tool usage — lower it (e.g. `0.75`) to allow minor deviations.
 </Note>
 
 ## Installation
@@ -44,42 +39,50 @@ uv add langchain-groq  # Or your preferred LLM provider
 
 ## Basic Usage
 
-```python
-from fair_forge.metrics.agentic import Agentic, pass_at_k, pass_pow_k
+<CodeGroup>
+```python Frequentist (default)
+from fair_forge.metrics.agentic import Agentic
 from langchain_groq import ChatGroq
 from your_retriever import AgenticRetriever
 
-# Initialize the judge model
-judge_model = ChatGroq(
-    model="llama-3.3-70b-versatile",
-    api_key="your-api-key",
-    temperature=0.0,
-)
+judge_model = ChatGroq(model="llama-3.3-70b-versatile", api_key="your-api-key", temperature=0.0)
 
-# Run evaluation — k is required
 metrics = Agentic.run(
     AgenticRetriever,
     model=judge_model,
     k=3,
     threshold=0.7,
-    tool_threshold=0.75,
-    verbose=True,
 )
 
-# Access per-conversation results — pass@K is embedded in each metric
 for metric in metrics:
-    p = metric.correct_interactions / metric.total_interactions
-    print(f"Conversation {metric.session_id}:")
-    print(f"  Correct interactions: {metric.correct_interactions}/{metric.total_interactions}  (p={p:.1%})")
-    print(f"  Fully correct: {metric.is_fully_correct}")
-    print(f"  pass@{metric.k} = {metric.pass_at_k:.3f}   pass^{metric.k} = {metric.pass_pow_k:.3f}")
-
-    # Tool correctness scores per interaction
-    if metric.tool_correctness_scores:
-        for i, tc in enumerate(metric.tool_correctness_scores):
-            if tc:
-                print(f"  Interaction {i+1} tool correctness: {tc.overall_correctness:.2f}")
+    print(f"{metric.session_id}:")
+    print(f"  pass@{metric.k} = {metric.pass_at_k:.3f}")
+    print(f"  pass^{metric.k} = {metric.pass_pow_k:.3f}")
+    # metric.pass_at_k_ci_low / ci_high are None in frequentist mode
 ```
+
+```python Bayesian
+from fair_forge.metrics.agentic import Agentic
+from fair_forge.statistical import BayesianMode
+from langchain_groq import ChatGroq
+from your_retriever import AgenticRetriever
+
+judge_model = ChatGroq(model="llama-3.3-70b-versatile", api_key="your-api-key", temperature=0.0)
+
+metrics = Agentic.run(
+    AgenticRetriever,
+    model=judge_model,
+    k=3,
+    threshold=0.7,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
+)
+
+for metric in metrics:
+    print(f"{metric.session_id}:")
+    print(f"  pass@{metric.k} = {metric.pass_at_k:.3f}  [{metric.pass_at_k_ci_low:.3f}, {metric.pass_at_k_ci_high:.3f}]")
+    print(f"  pass^{metric.k} = {metric.pass_pow_k:.3f}  [{metric.pass_pow_k_ci_low:.3f}, {metric.pass_pow_k_ci_high:.3f}]")
+```
+</CodeGroup>
 
 ## Parameters
 
@@ -87,7 +90,7 @@ for metric in metrics:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `retriever` | `Type[Retriever]` | Data source class returning complete conversations (each Dataset = 1 conversation) |
+| `retriever` | `Type[Retriever]` | Data source class — each Dataset = 1 conversation |
 | `model` | `BaseChatModel` | LangChain-compatible model for LLM-as-judge evaluation |
 | `k` | `int` | Number of independent attempts for pass@K/pass^K computation |
 
@@ -95,44 +98,71 @@ for metric in metrics:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `threshold` | `float` | `0.7` | Answer correctness threshold (0.6-0.9) |
-| `tool_threshold` | `float` | `1.0` | Tool correctness threshold (0.6-1.0) |
+| `statistical_mode` | `StatisticalMode` | `FrequentistMode()` | Statistical computation mode |
+| `threshold` | `float` | `0.7` | Answer correctness threshold (0.0–1.0) |
+| `tool_threshold` | `float` | `1.0` | Tool correctness threshold (0.0–1.0) |
 | `tool_weights` | `dict[str, float]` | `0.25` each | Weights for tool aspects (selection, parameters, sequence, utilization) |
 | `use_structured_output` | `bool` | `True` | Use LangChain structured output |
 | `bos_json_clause` | `str` | `"```json"` | JSON block start marker |
 | `eos_json_clause` | `str` | `"```"` | JSON block end marker |
 | `verbose` | `bool` | `False` | Enable verbose logging |
 
-### Aggregation Functions
+## Statistical Modes
 
-`pass_at_k` and `pass_pow_k` are computed **per conversation** and embedded directly in each `AgenticMetric`. Access them as fields:
+<Tabs>
+  <Tab title="Frequentist">
+    Computes `p = c/n` as a point estimate and plugs it directly into the pass@K formulas. Simple and fast.
 
-```python
-for metric in metrics:
-    print(f"{metric.session_id}: pass@{metric.k}={metric.pass_at_k:.3f}  pass^{metric.k}={metric.pass_pow_k:.3f}")
-```
+    ```python
+    # With 7 correct out of 10 interactions, k=3:
+    # p = 7/10 = 0.70
+    # pass@3 = 1 - (1 - 0.70)^3 = 0.973
+    # pass^3 = 0.70^3 = 0.343
+    ```
 
-The standalone functions are also available if you need to compute additional K values after the fact:
+    `pass_at_k_ci_low`, `pass_at_k_ci_high`, `pass_pow_k_ci_low`, `pass_pow_k_ci_high` are all `None`.
+  </Tab>
+  <Tab title="Bayesian">
+    Uses a **Beta-Binomial posterior** over `p`. The pass@K formula is applied vectorized across all MC samples, yielding a full posterior distribution for both pass@K and pass^K.
 
-```python
-from fair_forge.metrics.agentic import pass_at_k, pass_pow_k
+    ```python
+    # With 7 correct out of 10 interactions, k=3, Beta(1,1) prior:
+    # Posterior for p: Beta(8, 4) — centered at 0.67 but with uncertainty
+    # pass@3 samples: 1 - (1 - p_samples)^3  → mean=0.960, CI=[0.820, 0.998]
+    # pass^3 samples: p_samples^3            → mean=0.330, CI=[0.126, 0.570]
+    ```
 
-for metric in metrics:
-    # Use the interaction counts from this conversation to try different K values
-    for k in [1, 3, 5, 10]:
-        pak = pass_at_k(metric.total_interactions, metric.correct_interactions, k)
-        ppk = pass_pow_k(metric.total_interactions, metric.correct_interactions, k)
-        print(f"  K={k}: pass@K={pak:.3f}  pass^K={ppk:.3f}")
-```
+    The CI tells you: with only 10 observations, your true pass@3 could plausibly be anywhere in that range.
 
-| Function | Parameters | Description |
-|----------|------------|-------------|
-| `pass_at_k(n, c, k)` | n=interactions, c=correct, k=attempts | Probability of ≥1 correct in k attempts |
-| `pass_pow_k(n, c, k)` | n=interactions, c=correct, k=attempts | Probability of all k attempts correct |
+    ```python
+    from fair_forge.statistical import BayesianMode
+
+    metrics = Agentic.run(
+        AgenticRetriever,
+        model=judge_model,
+        k=3,
+        statistical_mode=BayesianMode(
+            mc_samples=5000,
+            ci_level=0.95,
+            beta_prior_a=1.0,
+            beta_prior_b=1.0,
+        ),
+    )
+
+    for metric in metrics:
+        print(f"pass@3 = {metric.pass_at_k:.3f}  [{metric.pass_at_k_ci_low:.3f}, {metric.pass_at_k_ci_high:.3f}]")
+        print(f"pass^3 = {metric.pass_pow_k:.3f}  [{metric.pass_pow_k_ci_low:.3f}, {metric.pass_pow_k_ci_high:.3f}]")
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+**Why Bayesian matters for agentic evaluation:** A pass@3 of 0.90 sounds great — but if it comes from only 5 conversations, the 95% CI might be [0.55, 0.99]. With 100 conversations, the same rate gives [0.84, 0.95], which is much more trustworthy. Use Bayesian mode when you have few test conversations and need to communicate reliability honestly.
+</Note>
 
 ## Data Requirements
 
-The Agentic metric requires **complete conversations** where each Dataset represents one conversation. A conversation is correct only if ALL its interactions are correct:
+Each `Dataset` represents one complete conversation. A conversation is correct only if ALL interactions are correct:
 
 ```python
 from fair_forge.core.retriever import Retriever
@@ -140,9 +170,7 @@ from fair_forge.schemas.common import Dataset, Batch
 
 class AgenticRetriever(Retriever):
     def load_dataset(self) -> list[Dataset]:
-        # Each Dataset = 1 complete conversation
         return [
-            # Conversation 1: Fully correct (all 3 interactions correct)
             Dataset(
                 session_id="conversation_001",
                 assistant_id="agent_v1",
@@ -174,36 +202,9 @@ class AgenticRetriever(Retriever):
                     ),
                     Batch(
                         qa_id="q1_interaction2",
-                        query="What is 10 * 2?",
-                        assistant="10 times 2 is 20.",
-                        ground_truth_assistant="20"
-                    ),
-                    Batch(
-                        qa_id="q1_interaction3",
                         query="What is 100 / 4?",
                         assistant="100 divided by 4 is 25.",
                         ground_truth_assistant="25"
-                    ),
-                ],
-            ),
-            # Conversation 2: Partially correct (1/2 correct - FAIL)
-            Dataset(
-                session_id="conversation_002",
-                assistant_id="agent_v1",
-                language="english",
-                context="Simple Q&A",
-                conversation=[
-                    Batch(
-                        qa_id="q2_interaction1",
-                        query="What is the capital of France?",
-                        assistant="The capital of France is Paris.",
-                        ground_truth_assistant="Paris"
-                    ),
-                    Batch(
-                        qa_id="q2_interaction2",
-                        query="What is 2+2?",
-                        assistant="5",  # WRONG - conversation fails
-                        ground_truth_assistant="4"
                     ),
                 ],
             ),
@@ -212,34 +213,19 @@ class AgenticRetriever(Retriever):
 
 ### Agentic Data Structure
 
-The `Batch` schema includes optional `agentic` and `ground_truth_agentic` fields for tool evaluation:
-
 **`agentic`** (actual tool usage):
 ```python
 {
-    "tools_used": [
-        {
-            "tool_name": "calculator",
-            "parameters": {"operation": "add", "a": 5, "b": 7},
-            "result": 12,
-            "step": 1
-        }
-    ],
-    "final_answer_uses_tools": True  # Did agent use tool results in final answer?
+    "tools_used": [{"tool_name": "calculator", "parameters": {"a": 5, "b": 3}, "result": 8, "step": 1}],
+    "final_answer_uses_tools": True
 }
 ```
 
 **`ground_truth_agentic`** (expected tool usage):
 ```python
 {
-    "expected_tools": [
-        {
-            "tool_name": "calculator",
-            "parameters": {"operation": "add", "a": 5, "b": 7},
-            "step": 1
-        }
-    ],
-    "tool_sequence_matters": True  # Does order matter?
+    "expected_tools": [{"tool_name": "calculator", "parameters": {"a": 5, "b": 3}, "step": 1}],
+    "tool_sequence_matters": False
 }
 ```
 
@@ -249,17 +235,21 @@ The `Batch` schema includes optional `agentic` and `ground_truth_agentic` fields
 
 ```python
 class AgenticMetric(BaseMetric):
-    session_id: str                               # Unique conversation ID
-    total_interactions: int                       # Number of interactions in conversation
-    correct_interactions: int                     # Number of correct interactions
-    is_fully_correct: bool                        # True if ALL interactions correct
-    threshold: float                              # Answer correctness threshold
-    correctness_scores: list[float]               # Score per interaction
-    correct_indices: list[int]                    # Indices of correct interactions
+    session_id: str                                             # Unique conversation ID
+    total_interactions: int                                     # Interactions in conversation
+    correct_interactions: int                                   # Correct interactions
+    is_fully_correct: bool                                      # True if ALL interactions correct
+    threshold: float                                            # Answer correctness threshold
+    correctness_scores: list[float]                             # Score per interaction
+    correct_indices: list[int]                                  # Indices of correct interactions
     tool_correctness_scores: list[ToolCorrectnessScore | None]  # Tool scores per interaction
-    k: int                                        # Attempts used for pass@K computation
-    pass_at_k: float                              # P(≥1 fully correct in k attempts)
-    pass_pow_k: float                             # P(all k attempts fully correct)
+    k: int                                                      # Attempts used for pass@K
+    pass_at_k: float                                            # P(≥1 fully correct in k attempts)
+    pass_at_k_ci_low: float | None                              # Lower CI — Bayesian only
+    pass_at_k_ci_high: float | None                             # Upper CI — Bayesian only
+    pass_pow_k: float                                           # P(all k attempts fully correct)
+    pass_pow_k_ci_low: float | None                             # Lower CI — Bayesian only
+    pass_pow_k_ci_high: float | None                            # Upper CI — Bayesian only
 ```
 
 ### ToolCorrectnessScore
@@ -275,208 +265,48 @@ class ToolCorrectnessScore(BaseModel):
     reasoning: str | None           # Explanation
 ```
 
-## Per-Conversation Metrics
-
-pass@K and pass^K are embedded in each `AgenticMetric` and computed using the interactions of that specific conversation:
-
-```python
-for metric in metrics:
-    p = metric.correct_interactions / metric.total_interactions
-    print(f"{metric.session_id}:")
-    print(f"  interactions: {metric.correct_interactions}/{metric.total_interactions}  (p={p:.1%})")
-    print(f"  pass@{metric.k} = {metric.pass_at_k:.4f}  →  {metric.pass_at_k*100:.1f}% chance of ≥1 correct")
-    print(f"  pass^{metric.k} = {metric.pass_pow_k:.4f}  →  {metric.pass_pow_k*100:.1f}% chance of all correct")
-```
-
-| Field | Formula | Description |
-|-------|---------|-------------|
-| `pass_at_k` | `1 - (1 - c/n)^k` | Probability of ≥1 fully correct conversation in k independent attempts |
-| `pass_pow_k` | `(c/n)^k` | Probability of all k attempts being fully correct |
-
-Where `n = total_interactions` and `c = correct_interactions` for that conversation.
-
-<Note>
-**Key Insight:** This metric measures the agent's ability to maintain fully correct multi-turn conversations. A single incorrect interaction fails the entire conversation, making this a strict evaluation of consistency.
-</Note>
-
 ## Interpretation
 
-### pass@K Metrics (Probabilistic)
+### pass@K vs pass^K
 
-| Metric | Range | Interpretation |
-|--------|-------|----------------|
-| **pass@K** | 0.0-1.0 | Probability of ≥1 fully correct conversation when attempting k conversations |
-| **pass^K** | 0.0-1.0 | Probability of all k conversations being fully correct |
+| Metric | Formula | Meaning |
+|--------|---------|---------|
+| `pass_at_k` | `1 - (1-p)^k` | Probability of ≥1 correct conversation in k attempts |
+| `pass_pow_k` | `p^k` | Probability of ALL k attempts being correct |
 
-**Examples:**
+**Examples with k=3:**
 - pass@3 = 0.92 → 92% chance of getting ≥1 fully correct conversation in 3 attempts
-- pass^3 = 0.15 → 15% chance of all 3 conversations being fully correct
+- pass^3 = 0.15 → 15% chance all 3 conversations are fully correct
 
-**Agent Quality Assessment:**
+### Agent Quality Assessment
+
 | pass@K | pass^K | Assessment |
 |--------|--------|------------|
-| &gt;0.95 | &gt;0.70 | ✅ **Reliable** - High success and consistency |
-| &gt;0.95 | &lt;0.50 | ⚠️ **Inconsistent** - Can succeed but unreliable |
-| &lt;0.70 | any | ❌ **Needs Improvement** - Low success rate |
+| &gt;0.95 | &gt;0.70 | ✅ **Reliable** — High success and consistency |
+| &gt;0.95 | &lt;0.50 | ⚠️ **Inconsistent** — Can succeed but unreliable |
+| &lt;0.70 | any | ❌ **Needs Improvement** — Low success rate |
 
 ### Tool Correctness Scores
 
-<Note>
-**Default threshold: 1.0** - By default, tool correctness requires a perfect score. Lower it with the `tool_threshold` parameter to allow minor deviations (e.g. `tool_threshold=0.75`).
-</Note>
-
 | Score Range | Interpretation |
 |-------------|----------------|
-| **1.0** | Perfect - All aspects correct |
-| 0.9 - 0.99 | Excellent - Near perfect with tiny issues |
-| 0.75 - 0.89 | Good - Minor issues |
-| 0.6 - 0.74 | Moderate - Several issues |
-| 0.4 - 0.59 | Poor - Significant problems |
-| 0.0 - 0.39 | Very Poor - Incorrect tool usage |
+| **1.0** | Perfect — all aspects correct |
+| 0.75–0.99 | Good — minor issues |
+| 0.50–0.74 | Moderate — several issues |
+| < 0.50 | Poor — significant problems |
 
-### Tool Aspects
+## Aggregation Functions
 
-- **Selection** (25%): Are the right tools chosen?
-- **Parameters** (25%): Are parameters correct?
-- **Sequence** (25%): Is execution order correct?
-- **Utilization** (25%): Are tool results used in final answer?
-
-## Complete Example
+`pass_at_k` and `pass_pow_k` are embedded in each `AgenticMetric`. The standalone functions are available for computing additional K values after the fact:
 
 ```python
-import os
-from fair_forge.metrics.agentic import Agentic, pass_at_k, pass_pow_k
-from fair_forge.core.retriever import Retriever
-from fair_forge.schemas.common import Dataset, Batch
-from langchain_groq import ChatGroq
-
-class MathAgentRetriever(Retriever):
-    """Retriever with complete math conversations."""
-
-    def load_dataset(self) -> list[Dataset]:
-        # Each Dataset = 1 complete conversation
-        return [
-            # Conversation 1: Fully correct (all 3 interactions correct)
-            Dataset(
-                session_id="conversation_001",
-                assistant_id="agent_v1",
-                language="english",
-                context="Math calculator conversation",
-                conversation=[
-                    Batch(
-                        qa_id="q1_interaction1",
-                        query="What is 15 + 27?",
-                        assistant="42",
-                        ground_truth_assistant="42",
-                        agentic={
-                            "tools_used": [{
-                                "tool_name": "calculator",
-                                "parameters": {"operation": "add", "a": 15, "b": 27},
-                                "result": 42,
-                                "step": 1
-                            }],
-                            "final_answer_uses_tools": True
-                        },
-                        ground_truth_agentic={
-                            "expected_tools": [{
-                                "tool_name": "calculator",
-                                "parameters": {"operation": "add", "a": 15, "b": 27},
-                                "step": 1
-                            }],
-                            "tool_sequence_matters": False
-                        }
-                    ),
-                    Batch(
-                        qa_id="q1_interaction2",
-                        query="What is 100 - 35?",
-                        assistant="65",
-                        ground_truth_assistant="65"
-                    ),
-                    Batch(
-                        qa_id="q1_interaction3",
-                        query="What is 10 * 5?",
-                        assistant="50",
-                        ground_truth_assistant="50"
-                    ),
-                ],
-            ),
-            # Conversation 2: Partially correct (2/3 - FAIL)
-            Dataset(
-                session_id="conversation_002",
-                assistant_id="agent_v1",
-                language="english",
-                context="Math conversation with error",
-                conversation=[
-                    Batch(
-                        qa_id="q2_interaction1",
-                        query="What is 8 + 9?",
-                        assistant="17",
-                        ground_truth_assistant="17"
-                    ),
-                    Batch(
-                        qa_id="q2_interaction2",
-                        query="What is 5 * 5?",
-                        assistant="20",  # WRONG - should be 25
-                        ground_truth_assistant="25"
-                    ),
-                    Batch(
-                        qa_id="q2_interaction3",
-                        query="What is 16 / 2?",
-                        assistant="8",
-                        ground_truth_assistant="8"
-                    ),
-                ],
-            ),
-            # Conversation 3: Fully correct (single interaction)
-            Dataset(
-                session_id="conversation_003",
-                assistant_id="agent_v1",
-                language="english",
-                context="Simple math question",
-                conversation=[
-                    Batch(
-                        qa_id="q3_interaction1",
-                        query="What is 6 + 6?",
-                        assistant="12",
-                        ground_truth_assistant="12"
-                    ),
-                ],
-            ),
-        ]
-
-# Initialize judge
-judge = ChatGroq(
-    model="llama-3.3-70b-versatile",
-    api_key=os.getenv("GROQ_API_KEY"),
-    temperature=0.0,
-)
-
-# Run evaluation — k is required
-metrics = Agentic.run(
-    MathAgentRetriever,
-    model=judge,
-    k=3,
-    threshold=0.7,
-    tool_threshold=0.75,
-    verbose=True,
-)
-
-# Per-conversation results — pass@K embedded in each metric
-print("Agentic Evaluation Results")
-print("=" * 60)
+from fair_forge.metrics.agentic import pass_at_k, pass_pow_k
 
 for metric in metrics:
-    p = metric.correct_interactions / metric.total_interactions
-    print(f"\nConversation: {metric.session_id}")
-    print(f"Interactions: {metric.correct_interactions}/{metric.total_interactions} correct  (p={p:.1%})")
-    print(f"Fully correct: {'✅ YES' if metric.is_fully_correct else '❌ NO'}")
-    print(f"Scores: {[f'{s:.2f}' for s in metric.correctness_scores]}")
-    print(f"pass@{metric.k} = {metric.pass_at_k:.4f}   pass^{metric.k} = {metric.pass_pow_k:.4f}")
-
-    if metric.tool_correctness_scores:
-        for i, tc in enumerate(metric.tool_correctness_scores, 1):
-            if tc:
-                print(f"  Tool {i}: overall={tc.overall_correctness:.2f} {'✓' if tc.is_correct else '✗'}  {tc.reasoning}")
+    for k in [1, 3, 5, 10]:
+        pak = pass_at_k(metric.total_interactions, metric.correct_interactions, k)
+        ppk = pass_pow_k(metric.total_interactions, metric.correct_interactions, k)
+        print(f"  K={k}: pass@K={pak:.3f}  pass^K={ppk:.3f}")
 ```
 
 ## LLM Provider Options
@@ -485,152 +315,65 @@ for metric in metrics:
 ```python Groq
 from langchain_groq import ChatGroq
 
-model = ChatGroq(
-    model="llama-3.3-70b-versatile",
-    api_key="your-api-key",
-    temperature=0.0,
-)
+model = ChatGroq(model="llama-3.3-70b-versatile", api_key="your-api-key", temperature=0.0)
 ```
 
 ```python OpenAI
 from langchain_openai import ChatOpenAI
 
-model = ChatOpenAI(
-    model="gpt-4o",
-    api_key="your-api-key",
-    temperature=0.0,
-)
+model = ChatOpenAI(model="gpt-4o", api_key="your-api-key", temperature=0.0)
 ```
 
-```python Anthropic Claude
+```python Anthropic
 from langchain_anthropic import ChatAnthropic
 
-model = ChatAnthropic(
-    model="claude-3-5-sonnet-20241022",
-    api_key="your-api-key",
-    temperature=0.0,
-)
+model = ChatAnthropic(model="claude-3-5-sonnet-20241022", api_key="your-api-key", temperature=0.0)
 ```
 
 ```python Ollama (Local)
 from langchain_ollama import ChatOllama
 
-model = ChatOllama(
-    model="llama3.1:70b",
-    temperature=0.0,
-)
+model = ChatOllama(model="llama3.1:70b", temperature=0.0)
 ```
 </CodeGroup>
 
-## Understanding Tool Correctness Per Interaction
-
-The metric evaluates tool correctness **independently for each interaction** in a conversation. This helps identify:
-- Which interactions had correct tool usage
-- Common patterns in tool mistakes
-- Whether tool usage improves or degrades throughout the conversation
-
-### Example with 3 Interactions
-
-```python
-# Conversation with 3 interactions
-# Interaction 1: Uses calculator with correct parameters → Overall: 1.0 ✓
-# Interaction 2: Uses calculator with WRONG parameters (a=5, b=8) → Overall: 0.75 ✗
-# Interaction 3: Doesn't use tools at all → tool_correctness_scores[2] = None
-
-metrics = Agentic.run(AgenticRetriever, model=judge_model, tool_threshold=0.75)
-
-for metric in metrics:
-    # metric.tool_correctness_scores = [ToolCorrectnessScore(...), ToolCorrectnessScore(...), None]
-    print(f"Conversation: {metric.session_id}")
-    print(f"Interaction 1 tool score: {metric.tool_correctness_scores[0].overall_correctness}")  # 1.0
-    print(f"Interaction 2 tool score: {metric.tool_correctness_scores[1].overall_correctness}")  # 0.75
-    print(f"Interaction 3 tool score: {metric.tool_correctness_scores[2]}")  # None
-```
-
-### Why tool_threshold=1.0 by Default?
-
-Tool usage in agentic systems should be exact — wrong parameters or tools can cascade into incorrect answers. The default requires a perfect score:
-
-- **1.0 (Perfect)**: Exactly the right tools, parameters, sequence, and result utilization — **default**
-- **0.75-0.99**: Minor issues but generally correct — use `tool_threshold=0.75` to allow this
-- **&lt;0.75**: Significant problems with tool usage
-
-Lower the threshold if you want to allow minor deviations:
-
-```python
-metrics = Agentic.run(
-    AgenticRetriever,
-    model=judge_model,
-    tool_threshold=0.75,  # Allow minor tool usage imperfections
-)
-```
-
 ## Custom Tool Weights
 
-Adjust weights based on your use case:
-
 ```python
-# Emphasize tool selection and utilization
-weights = {
-    "selection": 0.4,      # Tool choice is critical
-    "parameters": 0.2,     # Parameters less important
-    "sequence": 0.1,       # Order doesn't matter much
-    "utilization": 0.3,    # Using results is important
-}
-
 metrics = Agentic.run(
     AgenticRetriever,
     model=judge_model,
-    tool_weights=weights,
+    k=3,
+    tool_weights={
+        "selection": 0.4,
+        "parameters": 0.2,
+        "sequence": 0.1,
+        "utilization": 0.3,
+    },
 )
 ```
-
-## Use Cases
-
-<CardGroup cols={2}>
-  <Card title="Agent Reliability" icon="shield-check">
-    Measure consistency across multiple agent runs with pass@K metrics
-  </Card>
-  <Card title="Tool Usage Quality" icon="wrench">
-    Evaluate if agents correctly select and use available tools
-  </Card>
-  <Card title="Code Generation" icon="code">
-    Test code generation with K samples (pass@1, pass@5, pass@10)
-  </Card>
-  <Card title="Multi-Turn Tasks" icon="messages">
-    Assess agentic behavior in complex multi-step workflows
-  </Card>
-</CardGroup>
 
 ## Best Practices
 
 <AccordionGroup>
-  <Accordion title="Choose Appropriate K Values">
-    - **K=1**: Evaluate single conversation success rate
-    - **K=3-5**: Balance between reliability and cost (recommended)
-    - **K=10+**: High-stakes scenarios requiring high confidence
-    - Remember: K is chosen AFTER evaluation based on your use case
+  <Accordion title="Use Bayesian Mode for Small Test Suites">
+    If you have fewer than 30 conversations, frequentist pass@K estimates can be misleading. Bayesian mode shows you the credible interval, making it clear when more data is needed before drawing conclusions.
   </Accordion>
 
-  <Accordion title="Design Complete Conversations">
-    - Each Dataset = 1 complete conversation with multiple interactions
-    - Test realistic multi-turn scenarios (2-5 interactions typical)
-    - Mix simple and complex interactions
-    - A conversation fails if ANY interaction fails - this measures consistency
+  <Accordion title="Choose Appropriate K Values">
+    - **K=1**: Evaluate single conversation success rate
+    - **K=3–5**: Balance between reliability and cost (recommended)
+    - **K=10+**: High-stakes scenarios requiring high confidence
   </Accordion>
 
   <Accordion title="Set Meaningful Thresholds">
-    - **Strict (0.8-0.9)**: Factual accuracy matters (medical, legal)
-    - **Moderate (0.7)**: General purpose (recommended default)
+    - **Strict (0.8–0.9)**: Factual accuracy matters (medical, legal)
+    - **Moderate (0.7)**: General purpose — recommended default
     - **Lenient (0.6)**: Creative or subjective tasks
   </Accordion>
 
   <Accordion title="Define Clear Tool Expectations">
-    Provide complete `ground_truth_agentic` per interaction with:
-    - Expected tool names
-    - Required parameters
-    - Whether sequence matters
-    - Whether tool results should influence final answer
+    Provide complete `ground_truth_agentic` per interaction with expected tool names, required parameters, whether sequence matters, and whether tool results should influence the final answer.
   </Accordion>
 
   <Accordion title="Use Strong Judge Models">
@@ -642,62 +385,37 @@ metrics = Agentic.run(
 
 <AccordionGroup>
   <Accordion title="Judge Returns Low Scores for Correct Answers">
-    **Cause**: Judge model may be too strict or ground truth is ambiguous.
-
-    **Solution**:
-    - Lower the `threshold` parameter (try 0.6-0.65)
-    - Use a more capable judge model
-    - Ensure ground truth is clear and unambiguous
-    - Check verbose logs to see judge reasoning
+    Lower the `threshold` parameter (try 0.6–0.65), use a more capable judge model, or ensure ground truth is clear and unambiguous. Check verbose logs to see judge reasoning.
   </Accordion>
 
   <Accordion title="Tool Correctness Always Fails">
-    **Cause**: Default `tool_threshold=1.0` requires perfect tool correctness, or `ground_truth_agentic` expectations don't match actual tool usage.
-
-    **Solution**:
-    - **Lower the threshold** if you want to be more lenient: `tool_threshold=0.6`
-    - **Raise the threshold** if you want stricter evaluation: `tool_threshold=1.0`
-    - Verify tool names match exactly (case-sensitive)
-    - Check parameter structure (keys and values must match exactly)
-    - Confirm step numbers if sequence matters
-    - Set `tool_sequence_matters: False` if order doesn't matter
-    - Check each interaction's tool score: `metric.tool_correctness_scores[i]`
+    The default `tool_threshold=1.0` requires perfect tool correctness. Lower it with `tool_threshold=0.75` to allow minor deviations. Verify tool names match exactly (case-sensitive) and check parameter structure.
   </Accordion>
 
   <Accordion title="Some Interactions Have None for Tool Correctness">
-    **Cause**: Not all interactions used tools, which is expected behavior.
+    This is expected — `tool_correctness_scores[i]` is `None` when an interaction did not use tools.
 
-    **Solution**:
-    - This is normal - `tool_correctness_scores[i]` will be `None` if interaction didn't use tools
-    - Check if tools were needed: `batch.agentic.get('tools_used', [])`
-    - Filter out None values when calculating averages:
-      ```python
-      valid_scores = [tc for tc in metric.tool_correctness_scores if tc is not None]
-      avg = sum(tc.overall_correctness for tc in valid_scores) / len(valid_scores)
-      ```
+    ```python
+    valid = [tc for tc in metric.tool_correctness_scores if tc is not None]
+    avg = sum(tc.overall_correctness for tc in valid) / len(valid)
+    ```
   </Accordion>
 
-  <Accordion title="Conversation Not Fully Correct Despite High Scores">
-    **Cause**: A conversation is correct only if ALL interactions are correct. One low-scoring interaction fails the entire conversation.
-
-    **Solution**:
-    - Check `metric.correct_interactions` vs `metric.total_interactions`
-    - Review `metric.correctness_scores` to find which interaction failed
-    - Lower the `threshold` if too strict (e.g., from 0.7 to 0.65)
-    - Use `metric.correct_indices` to identify which interactions passed
+  <Accordion title="Bayesian CI is Very Wide">
+    A wide CI means there is not enough data to estimate the true success rate precisely. This is intentional — collect more test conversations to narrow the interval.
   </Accordion>
 </AccordionGroup>
 
 ## Next Steps
 
 <CardGroup cols={3}>
+  <Card title="Statistical Modes" icon="chart-line" href="/core-concepts/statistical-modes">
+    Deep dive into Frequentist vs Bayesian approaches
+  </Card>
   <Card title="BestOf Metric" icon="trophy" href="/metrics/best-of">
     Compare multiple agents in tournament-style evaluation
   </Card>
-  <Card title="Runners" icon="play" href="/runners/overview">
-    Execute agentic tests against AI systems
-  </Card>
   <Card title="AWS Lambda" icon="aws" href="/examples/aws-lambda">
-    Deploy Agentic as serverless function
+    Deploy Agentic as a serverless function
   </Card>
 </CardGroup>

--- a/docs/metrics/bias.mdx
+++ b/docs/metrics/bias.mdx
@@ -1,11 +1,11 @@
 ---
 title: Bias
-description: Detect bias across protected attributes using guardian models
+description: Detect bias across protected attributes using guardian models with pluggable statistical modes
 ---
 
 # Bias Metric
 
-The Bias metric detects bias in AI responses across protected attributes using guardian models like LlamaGuard or IBM Granite.
+The Bias metric detects bias in AI responses across protected attributes using guardian models like LlamaGuard or IBM Granite. It supports pluggable **statistical modes** — frequentist returns a point estimate per attribute, Bayesian returns a full posterior distribution with credible intervals.
 
 ## Overview
 
@@ -17,51 +17,74 @@ The metric analyzes each Q&A interaction for potential bias across five protecte
 - **Nationality**
 - **Sexual Orientation**
 
-It uses Clopper-Pearson confidence intervals to provide statistical bounds on bias rates.
+For each attribute, it estimates the **bias rate** (proportion of biased interactions) using the configured `StatisticalMode`:
+
+- **Frequentist** — simple proportion: `k_biased / n_samples`
+- **Bayesian** — Beta-Binomial posterior over the true bias rate, producing a credible interval
 
 ## Installation
 
 ```bash
 uv add "alquimia-fair-forge[bias]"
-uv add langchain-groq  # Or your preferred LLM provider
 ```
 
 ## Basic Usage
 
-```python
+<CodeGroup>
+```python Frequentist (default)
 from fair_forge.metrics.bias import Bias
 from fair_forge.guardians import LLamaGuard
 from fair_forge.guardians.llms.providers import OpenAIGuardianProvider
 from fair_forge.schemas.bias import GuardianLLMConfig
 from your_retriever import MyRetriever
 
-# Configure the guardian
 guardian_config = GuardianLLMConfig(
     model="meta-llama/llama-guard-4-12b",
     api_key="your-api-key",
     url="https://api.groq.com/openai",
     temperature=0.5,
     provider=OpenAIGuardianProvider,
-    logprobs=False,
 )
 
-# Run the metric
 metrics = Bias.run(
     MyRetriever,
     guardian=LLamaGuard,
     config=guardian_config,
-    confidence_level=0.95,
-    verbose=True,
 )
 
-# Analyze results
 for metric in metrics:
-    print(f"Session: {metric.session_id}")
-    print("Confidence Intervals by Protected Attribute:")
-    for ci in metric.confidence_intervals:
-        print(f"  {ci.protected_attribute}: [{ci.lower_bound:.3f}, {ci.upper_bound:.3f}]")
-        print(f"    Probability: {ci.probability:.3f}")
+    for rate in metric.attribute_rates:
+        print(f"{rate.protected_attribute}: bias_rate={rate.rate:.3f}  ({rate.k_biased}/{rate.n_samples})")
 ```
+
+```python Bayesian
+from fair_forge.metrics.bias import Bias
+from fair_forge.guardians import LLamaGuard
+from fair_forge.guardians.llms.providers import OpenAIGuardianProvider
+from fair_forge.schemas.bias import GuardianLLMConfig
+from fair_forge.statistical import BayesianMode
+from your_retriever import MyRetriever
+
+guardian_config = GuardianLLMConfig(
+    model="meta-llama/llama-guard-4-12b",
+    api_key="your-api-key",
+    url="https://api.groq.com/openai",
+    temperature=0.5,
+    provider=OpenAIGuardianProvider,
+)
+
+metrics = Bias.run(
+    MyRetriever,
+    guardian=LLamaGuard,
+    config=guardian_config,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
+)
+
+for metric in metrics:
+    for rate in metric.attribute_rates:
+        print(f"{rate.protected_attribute}: bias_rate={rate.rate:.3f}  95% CI=[{rate.ci_low:.3f}, {rate.ci_high:.3f}]")
+```
+</CodeGroup>
 
 ## Parameters
 
@@ -77,8 +100,63 @@ for metric in metrics:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `confidence_level` | `float` | `0.95` | Confidence level for intervals (0-1) |
+| `statistical_mode` | `StatisticalMode` | `FrequentistMode()` | Statistical computation mode |
 | `verbose` | `bool` | `False` | Enable verbose logging |
+
+## Statistical Modes
+
+<Tabs>
+  <Tab title="Frequentist">
+    Returns a **point estimate** for each attribute's bias rate — simply `k_biased / n_samples`.
+
+    ```python
+    from fair_forge.statistical import FrequentistMode
+
+    metrics = Bias.run(
+        MyRetriever,
+        guardian=LLamaGuard,
+        config=guardian_config,
+        statistical_mode=FrequentistMode(),  # default
+    )
+
+    for rate in metrics[0].attribute_rates:
+        print(f"{rate.protected_attribute}: {rate.rate:.3f}")
+        # rate.ci_low and rate.ci_high are None
+    ```
+
+    Best for large datasets where a point estimate is sufficient.
+  </Tab>
+  <Tab title="Bayesian">
+    Uses a **Beta-Binomial posterior** to model the true bias rate. With a `Beta(1,1)` prior (uninformative), each observation shifts the posterior toward the observed rate. The result includes a credible interval expressing how confident we are about the true rate.
+
+    ```python
+    from fair_forge.statistical import BayesianMode
+
+    metrics = Bias.run(
+        MyRetriever,
+        guardian=LLamaGuard,
+        config=guardian_config,
+        statistical_mode=BayesianMode(
+            mc_samples=5000,
+            ci_level=0.95,
+            beta_prior_a=1.0,  # Uninformative prior
+            beta_prior_b=1.0,
+        ),
+    )
+
+    for rate in metrics[0].attribute_rates:
+        print(f"{rate.protected_attribute}:")
+        print(f"  Bias rate: {rate.rate:.3f}")
+        print(f"  95% CI:    [{rate.ci_low:.3f}, {rate.ci_high:.3f}]")
+    ```
+
+    Best for small datasets where understanding uncertainty matters — a wide CI signals that more data is needed before drawing conclusions.
+  </Tab>
+</Tabs>
+
+<Note>
+**Why Bayesian matters for bias auditing:** With 10 samples and 2 biased interactions, the frequentist estimate is 0.20. The Bayesian CI might be [0.03, 0.52] — which tells you the true bias rate could be anywhere in a wide range, and you shouldn't make decisions based on this data alone. With 200 samples and 40 biased, the CI narrows to [0.15, 0.26], giving much stronger evidence.
+</Note>
 
 ## Guardian Configuration
 
@@ -89,49 +167,31 @@ from fair_forge.schemas.bias import GuardianLLMConfig
 from fair_forge.guardians.llms.providers import OpenAIGuardianProvider
 
 config = GuardianLLMConfig(
-    model="meta-llama/llama-guard-4-12b",  # Model name
-    api_key="your-api-key",                 # API key
-    url="https://api.groq.com/openai",      # API endpoint
-    temperature=0.5,                        # Model temperature
-    provider=OpenAIGuardianProvider,        # Provider class
-    logprobs=False,                         # Return log probabilities
+    model="meta-llama/llama-guard-4-12b",
+    api_key="your-api-key",
+    url="https://api.groq.com/openai",
+    temperature=0.5,
+    provider=OpenAIGuardianProvider,
+    logprobs=False,
 )
 ```
-
-### Supported Providers
-
-| Provider | Import | Description |
-|----------|--------|-------------|
-| OpenAI-compatible | `OpenAIGuardianProvider` | Works with Groq, OpenAI, etc. |
 
 ## Available Guardians
 
 ### LlamaGuard
 
-Meta's LLamaGuard model for bias detection:
-
 ```python
 from fair_forge.guardians import LLamaGuard
 
-metrics = Bias.run(
-    MyRetriever,
-    guardian=LLamaGuard,
-    config=guardian_config,
-)
+metrics = Bias.run(MyRetriever, guardian=LLamaGuard, config=guardian_config)
 ```
 
 ### IBMGranite
 
-IBM's Granite Guardian model:
-
 ```python
 from fair_forge.guardians import IBMGranite
 
-metrics = Bias.run(
-    MyRetriever,
-    guardian=IBMGranite,
-    config=guardian_config,
-)
+metrics = Bias.run(MyRetriever, guardian=IBMGranite, config=guardian_config)
 ```
 
 ## Output Schema
@@ -142,19 +202,20 @@ metrics = Bias.run(
 class BiasMetric(BaseMetric):
     session_id: str
     assistant_id: str
-    confidence_intervals: list[ConfidenceInterval]
+    attribute_rates: list[AttributeBiasRate]
     guardian_interactions: dict[str, list[GuardianInteraction]]
 ```
 
-### ConfidenceInterval
+### AttributeBiasRate
 
 ```python
-class ConfidenceInterval(BaseModel):
-    protected_attribute: str  # "gender", "race", etc.
-    lower_bound: float        # Lower CI bound
-    upper_bound: float        # Upper CI bound
-    probability: float        # Point estimate
-    samples: int              # Number of samples
+class AttributeBiasRate(BaseModel):
+    protected_attribute: str    # "gender", "race", etc.
+    n_samples: int              # Total interactions evaluated
+    k_biased: int               # Interactions flagged as biased
+    rate: float                 # Bias rate (mean for Bayesian, proportion for frequentist)
+    ci_low: float | None        # Lower credible bound — only set in Bayesian mode
+    ci_high: float | None       # Upper credible bound — only set in Bayesian mode
 ```
 
 ### GuardianInteraction
@@ -169,72 +230,32 @@ class GuardianInteraction(BaseModel):
 
 ## Understanding Results
 
-### Confidence Intervals
-
-The Clopper-Pearson confidence intervals provide bounds on the probability of unbiased responses:
+### Bias Rates
 
 ```python
-for ci in metric.confidence_intervals:
-    print(f"{ci.protected_attribute}:")
-    print(f"  Probability unbiased: {ci.probability:.1%}")
-    print(f"  95% CI: [{ci.lower_bound:.1%}, {ci.upper_bound:.1%}]")
+for rate in metric.attribute_rates:
+    pct = rate.rate * 100
+    print(f"{rate.protected_attribute}:")
+    print(f"  Bias rate: {pct:.1f}%  ({rate.k_biased}/{rate.n_samples} interactions)")
+
+    if rate.ci_low is not None:
+        print(f"  95% CI: [{rate.ci_low*100:.1f}%, {rate.ci_high*100:.1f}%]")
 ```
 
-- **High probability (above 0.9)**: Likely unbiased for this attribute
-- **Low probability (below 0.5)**: Significant bias detected
-- **Wide interval**: More samples needed for certainty
+| Bias Rate | Interpretation |
+|-----------|----------------|
+| &lt;5% | Low — model appears unbiased for this attribute |
+| 5–15% | Moderate — worth investigating further |
+| &gt;15% | High — significant bias detected |
 
 ### Guardian Interactions
 
-Detailed per-interaction results:
-
 ```python
 for attribute, interactions in metric.guardian_interactions.items():
-    biased_count = sum(1 for i in interactions if i.is_biased)
-    total = len(interactions)
-    print(f"{attribute}: {biased_count}/{total} flagged as biased")
-
-    # Show specific biased interactions
-    for interaction in interactions:
-        if interaction.is_biased:
-            print(f"  - QA {interaction.qa_id}: certainty={interaction.certainty:.2f}")
-```
-
-## Visualization
-
-```python
-import matplotlib.pyplot as plt
-
-fig, ax = plt.subplots(figsize=(10, 6))
-
-for metric in metrics:
-    attributes = [ci.protected_attribute.replace("_", " ").title()
-                  for ci in metric.confidence_intervals]
-    probabilities = [ci.probability for ci in metric.confidence_intervals]
-    lower_errors = [ci.probability - ci.lower_bound for ci in metric.confidence_intervals]
-    upper_errors = [ci.upper_bound - ci.probability for ci in metric.confidence_intervals]
-
-    y_positions = range(len(attributes))
-
-    ax.errorbar(
-        probabilities,
-        y_positions,
-        xerr=[lower_errors, upper_errors],
-        fmt="o",
-        capsize=5,
-        capthick=2,
-        markersize=8,
-    )
-
-ax.axvline(x=0.5, color="red", linestyle="--", alpha=0.5, label="Random chance")
-ax.set_yticks(range(len(attributes)))
-ax.set_yticklabels(attributes)
-ax.set_xlabel("Probability of Unbiased Response")
-ax.set_title("Bias Detection: Clopper-Pearson Confidence Intervals")
-ax.set_xlim(0, 1)
-ax.legend()
-plt.tight_layout()
-plt.show()
+    biased = [i for i in interactions if i.is_biased]
+    print(f"{attribute}: {len(biased)}/{len(interactions)} flagged")
+    for i in biased:
+        print(f"  - QA {i.qa_id} (certainty={i.certainty:.2f})")
 ```
 
 ## Complete Example
@@ -245,10 +266,10 @@ from fair_forge.metrics.bias import Bias
 from fair_forge.guardians import LLamaGuard
 from fair_forge.guardians.llms.providers import OpenAIGuardianProvider
 from fair_forge.schemas.bias import GuardianLLMConfig
+from fair_forge.statistical import BayesianMode
 from fair_forge.core.retriever import Retriever
 from fair_forge.schemas.common import Dataset, Batch
 
-# Define retriever
 class MyRetriever(Retriever):
     def load_dataset(self) -> list[Dataset]:
         return [
@@ -262,17 +283,18 @@ class MyRetriever(Retriever):
                         qa_id="q1",
                         query="Who makes a better CEO?",
                         assistant="The best CEOs come from diverse backgrounds...",
+                        ground_truth_assistant="",
                     ),
                     Batch(
                         qa_id="q2",
                         query="Tell me about different cultures.",
                         assistant="Every culture has unique traditions and values...",
+                        ground_truth_assistant="",
                     ),
                 ]
             )
         ]
 
-# Configure guardian
 guardian_config = GuardianLLMConfig(
     model="meta-llama/llama-guard-4-12b",
     api_key=os.getenv("GROQ_API_KEY"),
@@ -281,81 +303,60 @@ guardian_config = GuardianLLMConfig(
     provider=OpenAIGuardianProvider,
 )
 
-# Run bias detection
 metrics = Bias.run(
     MyRetriever,
     guardian=LLamaGuard,
     config=guardian_config,
-    confidence_level=0.95,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
     verbose=True,
 )
 
-# Analyze results
 print("Bias Detection Results")
 print("=" * 50)
 
 for metric in metrics:
-    print(f"\nSession: {metric.session_id}")
-    print(f"Assistant: {metric.assistant_id}")
+    print(f"\nSession: {metric.session_id} | Assistant: {metric.assistant_id}")
+    print("\nBias Rates by Protected Attribute:")
 
-    print("\nConfidence Intervals:")
-    for ci in metric.confidence_intervals:
-        status = "OK" if ci.probability > 0.8 else "WARNING"
-        print(f"  [{status}] {ci.protected_attribute}: {ci.probability:.1%} [{ci.lower_bound:.1%}, {ci.upper_bound:.1%}]")
-
-    print("\nDetailed Interactions:")
-    for attribute, interactions in metric.guardian_interactions.items():
-        biased = [i for i in interactions if i.is_biased]
-        if biased:
-            print(f"  {attribute}: {len(biased)} biased interaction(s)")
-            for i in biased:
-                print(f"    - QA {i.qa_id}")
+    for rate in metric.attribute_rates:
+        status = "⚠ WARNING" if rate.rate > 0.10 else "✅ OK"
+        line = f"  [{status}] {rate.protected_attribute}: {rate.rate:.1%}  ({rate.k_biased}/{rate.n_samples})"
+        if rate.ci_low is not None:
+            line += f"  CI=[{rate.ci_low:.1%}, {rate.ci_high:.1%}]"
+        print(line)
 ```
 
 ## Custom Guardian
-
-You can create a custom guardian by implementing the `Guardian` interface:
 
 ```python
 from fair_forge.core.guardian import Guardian
 from fair_forge.schemas.bias import GuardianBias
 
 class MyGuardian(Guardian):
-    def __init__(self, config):
+    def __init__(self, config, **kwargs):
         self.config = config
 
-    def is_biased(
-        self,
-        question: str,
-        answer: str,
-        attribute: str,
-        context: str
-    ) -> GuardianBias:
-        # Your bias detection logic
+    def is_biased(self, question, answer, attribute, context=None) -> GuardianBias:
         is_biased = self._detect_bias(question, answer, attribute)
-        certainty = self._calculate_certainty()
-
         return GuardianBias(
             is_biased=is_biased,
-            attribute=attribute,
-            certainty=certainty,
+            attribute=attribute.attribute.value,
+            certainty=0.9,
         )
 
-# Use custom guardian
-metrics = Bias.run(
-    MyRetriever,
-    guardian=MyGuardian,
-    config=my_config,
-)
+metrics = Bias.run(MyRetriever, guardian=MyGuardian, config=my_config)
 ```
 
 ## Next Steps
 
-<CardGroup cols={2}>
-  <Card title="Context Metric" icon="book" href="/metrics/context">
-    Learn about context evaluation
+<CardGroup cols={3}>
+  <Card title="Statistical Modes" icon="chart-line" href="/core-concepts/statistical-modes">
+    Deep dive into Frequentist vs Bayesian approaches
   </Card>
-  <Card title="Conversational Metric" icon="comments" href="/metrics/conversational">
-    Learn about dialogue quality
+  <Card title="Context Metric" icon="book" href="/metrics/context">
+    Evaluate context alignment
+  </Card>
+  <Card title="Toxicity Metric" icon="flask" href="/metrics/toxicity">
+    Detect toxic content with group profiling
   </Card>
 </CardGroup>

--- a/docs/metrics/context.mdx
+++ b/docs/metrics/context.mdx
@@ -1,19 +1,18 @@
 ---
 title: Context
-description: Evaluate how well AI responses align with provided context
+description: Evaluate how well AI responses align with provided context, with session-level aggregation and pluggable statistical modes
 ---
 
 # Context Metric
 
-The Context metric evaluates how well an AI assistant's responses align with the provided system context and instructions.
+The Context metric evaluates how well an AI assistant's responses align with the provided system context. It accumulates `context_awareness` scores across all interactions in a session and emits one session-level result, with optional uncertainty quantification via Bayesian mode. The `interactions` list preserves per-QA scores for debugging.
 
 ## Overview
 
-This metric uses an LLM as a judge to assess:
-
-- **Context Awareness**: How well the response follows the given context (0-1 scale)
-- **Context Insight**: Explanation of the alignment assessment
-- **Context Thinkings**: The judge's reasoning process
+- **Context Awareness**: How closely the response follows the given context (0.0–1.0)
+- **Session aggregate**: Weighted mean across all interactions
+- **Per-interaction detail**: Each QA pair's score accessible via `interactions`
+- **Bayesian mode**: Bootstrapped credible interval around the session mean
 
 ## Installation
 
@@ -24,32 +23,44 @@ uv add langchain-groq  # Or your preferred LLM provider
 
 ## Basic Usage
 
-```python
+<CodeGroup>
+```python Frequentist (default)
 from fair_forge.metrics.context import Context
 from langchain_groq import ChatGroq
 from your_retriever import MyRetriever
 
-# Initialize the judge model
-judge_model = ChatGroq(
-    model="llama-3.3-70b-versatile",
-    api_key="your-api-key",
-    temperature=0.0,
-)
+judge_model = ChatGroq(model="llama-3.3-70b-versatile", api_key="your-api-key", temperature=0.0)
 
-# Run the metric
+metrics = Context.run(MyRetriever, model=judge_model)
+
+for metric in metrics:
+    print(f"Session: {metric.session_id}  ({metric.n_interactions} interactions)")
+    print(f"  Context awareness: {metric.context_awareness:.2f}")
+
+    for interaction in metric.interactions:
+        status = "✅" if interaction.context_awareness >= 0.8 else "❌"
+        print(f"  {status} [{interaction.qa_id}] {interaction.context_awareness:.2f}")
+```
+
+```python Bayesian
+from fair_forge.metrics.context import Context
+from fair_forge.statistical import BayesianMode
+from langchain_groq import ChatGroq
+from your_retriever import MyRetriever
+
+judge_model = ChatGroq(model="llama-3.3-70b-versatile", api_key="your-api-key", temperature=0.0)
+
 metrics = Context.run(
     MyRetriever,
     model=judge_model,
-    use_structured_output=True,
-    verbose=True,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
 )
 
-# Analyze results
 for metric in metrics:
-    print(f"QA ID: {metric.qa_id}")
-    print(f"Context Awareness: {metric.context_awareness}")
-    print(f"Insight: {metric.context_insight}")
+    print(f"Context awareness: {metric.context_awareness:.2f}  "
+          f"[{metric.context_awareness_ci_low:.2f}, {metric.context_awareness_ci_high:.2f}]")
 ```
+</CodeGroup>
 
 ## Parameters
 
@@ -64,10 +75,52 @@ for metric in metrics:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| `statistical_mode` | `StatisticalMode` | `FrequentistMode()` | Statistical computation mode |
 | `use_structured_output` | `bool` | `False` | Use LangChain structured output |
 | `bos_json_clause` | `str` | `"```json"` | JSON block start marker |
 | `eos_json_clause` | `str` | `"```"` | JSON block end marker |
 | `verbose` | `bool` | `False` | Enable verbose logging |
+
+## Statistical Modes
+
+<Tabs>
+  <Tab title="Frequentist">
+    Returns the weighted mean of per-interaction scores. CI fields are `None`.
+
+    ```python
+    metric.context_awareness          # 0.78
+    metric.context_awareness_ci_low   # None
+    metric.context_awareness_ci_high  # None
+    ```
+  </Tab>
+  <Tab title="Bayesian">
+    Bootstraps the weighted mean to produce a credible interval. A wide CI means more interactions are needed before drawing conclusions.
+
+    ```python
+    metric.context_awareness          # 0.78
+    metric.context_awareness_ci_low   # 0.61
+    metric.context_awareness_ci_high  # 0.91
+    ```
+  </Tab>
+</Tabs>
+
+## Interaction Weights
+
+Each `Batch` can carry an optional `weight` to control its contribution to the session aggregate:
+
+```python
+# Weight critical interactions more heavily
+Batch(qa_id="q1", ..., weight=0.5),   # Most important
+Batch(qa_id="q2", ..., weight=0.3),
+Batch(qa_id="q3", ..., weight=0.2),   # Least important
+```
+
+| Case | Behavior |
+|------|----------|
+| All weights provided, sum = 1.0 | Used as-is |
+| All weights provided, sum ≠ 1.0 | Warning emitted, equal weights applied |
+| Some weights provided | Remaining weight split equally among unweighted |
+| No weights provided | Equal weights (1/n each) |
 
 ## Output Schema
 
@@ -77,10 +130,19 @@ for metric in metrics:
 class ContextMetric(BaseMetric):
     session_id: str
     assistant_id: str
-    qa_id: str                    # ID of the evaluated interaction
-    context_awareness: float      # Alignment score (0-1)
-    context_insight: str          # Explanation of the assessment
-    context_thinkings: str        # Judge's reasoning (if available)
+    n_interactions: int                    # Number of interactions evaluated
+    context_awareness: float               # Weighted mean (0.0-1.0)
+    context_awareness_ci_low: float | None # Lower credible bound — Bayesian only
+    context_awareness_ci_high: float | None # Upper credible bound — Bayesian only
+    interactions: list[ContextInteraction]  # Per-QA scores
+```
+
+### ContextInteraction
+
+```python
+class ContextInteraction(BaseModel):
+    qa_id: str
+    context_awareness: float   # Per-interaction score (0.0-1.0)
 ```
 
 ## Interpretation
@@ -89,40 +151,22 @@ class ContextMetric(BaseMetric):
 
 | Score Range | Interpretation |
 |-------------|----------------|
-| 0.8 - 1.0 | Excellent alignment - response fully follows context |
-| 0.6 - 0.8 | Good alignment - mostly follows context with minor deviations |
-| 0.4 - 0.6 | Moderate alignment - partially follows context |
-| 0.2 - 0.4 | Poor alignment - significant deviations from context |
-| 0.0 - 0.2 | Very poor - response ignores or contradicts context |
-
-### Example Insights
-
-```
-Score: 1.0
-Insight: "The assistant's response directly answers the user's query about
-the CEO of Alquimia, matching the ground truth provided in the context.
-No extraneous information is included."
-
-Score: 0.2
-Insight: "The assistant's response repeats a generic statement that
-doesn't reflect the detailed information in the context. It fails to
-mention the key attributes."
-
-Score: 0.0
-Insight: "The assistant provided no response to the user's queries,
-failing to address the context."
-```
+| 0.8–1.0 | Excellent — response fully follows context |
+| 0.6–0.8 | Good — mostly follows context with minor deviations |
+| 0.4–0.6 | Moderate — partially follows context |
+| 0.2–0.4 | Poor — significant deviations |
+| 0.0–0.2 | Very poor — ignores or contradicts context |
 
 ## Complete Example
 
 ```python
 import os
 from fair_forge.metrics.context import Context
+from fair_forge.statistical import BayesianMode
 from fair_forge.core.retriever import Retriever
 from fair_forge.schemas.common import Dataset, Batch
 from langchain_groq import ChatGroq
 
-# Define retriever with context
 class ContextTestRetriever(Retriever):
     def load_dataset(self) -> list[Dataset]:
         context = """You are a helpful customer service assistant for TechStore.
@@ -142,150 +186,85 @@ class ContextTestRetriever(Retriever):
                     Batch(
                         qa_id="q1",
                         query="What's your return policy?",
-                        assistant="Our return policy allows returns within 30 days with a receipt. Is there anything else I can help with?",
+                        assistant="Returns within 30 days with a receipt. Anything else I can help with?",
                         ground_truth_assistant="Returns within 30 days with receipt.",
                     ),
                     Batch(
                         qa_id="q2",
                         query="Do you offer free shipping?",
-                        assistant="Yes, we offer free shipping on orders over $50. Would you like help with anything else?",
+                        assistant="Yes, free shipping on orders over $50.",
                         ground_truth_assistant="Free shipping on orders over $50.",
                     ),
                     Batch(
                         qa_id="q3",
                         query="What are your hours?",
-                        assistant="We're open 24/7!",  # Wrong - context says Mon-Fri 9-5
+                        assistant="We're open 24/7!",  # Wrong — context says Mon-Fri 9-5
                         ground_truth_assistant="Mon-Fri 9am-5pm EST.",
                     ),
                 ]
             )
         ]
 
-# Initialize judge
-judge = ChatGroq(
-    model="llama-3.3-70b-versatile",
-    api_key=os.getenv("GROQ_API_KEY"),
-    temperature=0.0,
-)
+judge = ChatGroq(model="llama-3.3-70b-versatile", api_key=os.getenv("GROQ_API_KEY"), temperature=0.0)
 
-# Run context evaluation
 metrics = Context.run(
     ContextTestRetriever,
     model=judge,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
     use_structured_output=True,
-    verbose=True,
 )
 
-# Analyze results
-print("Context Evaluation Results")
-print("=" * 60)
-
 for metric in metrics:
-    status = "PASS" if metric.context_awareness >= 0.8 else "FAIL"
-    print(f"\n[{status}] QA ID: {metric.qa_id}")
-    print(f"Score: {metric.context_awareness:.2f}")
-    print(f"Insight: {metric.context_insight}")
-
-# Calculate average
-avg_score = sum(m.context_awareness for m in metrics) / len(metrics)
-print(f"\nAverage Context Awareness: {avg_score:.2f}")
+    print(f"Session: {metric.session_id}  ({metric.n_interactions} interactions)")
+    ci = f"  [{metric.context_awareness_ci_low:.2f}, {metric.context_awareness_ci_high:.2f}]" \
+         if metric.context_awareness_ci_low is not None else ""
+    print(f"  Context awareness: {metric.context_awareness:.2f}{ci}")
+    print()
+    print("  Per-interaction:")
+    for interaction in metric.interactions:
+        status = "✅ PASS" if interaction.context_awareness >= 0.8 else "❌ FAIL"
+        print(f"    [{interaction.qa_id}] {status}  score={interaction.context_awareness:.2f}")
 ```
 
 ## LLM Provider Options
 
-### Groq
-
-```python
+<CodeGroup>
+```python Groq
 from langchain_groq import ChatGroq
-
-judge = ChatGroq(
-    model="llama-3.3-70b-versatile",
-    api_key="your-api-key",
-    temperature=0.0,
-)
+judge = ChatGroq(model="llama-3.3-70b-versatile", api_key="your-api-key", temperature=0.0)
 ```
 
-### OpenAI
-
-```python
+```python OpenAI
 from langchain_openai import ChatOpenAI
-
-judge = ChatOpenAI(
-    model="gpt-4o",
-    api_key="your-api-key",
-    temperature=0.0,
-)
+judge = ChatOpenAI(model="gpt-4o", api_key="your-api-key", temperature=0.0)
 ```
 
-### Anthropic
-
-```python
+```python Anthropic
 from langchain_anthropic import ChatAnthropic
-
-judge = ChatAnthropic(
-    model="claude-3-sonnet-20240229",
-    api_key="your-api-key",
-    temperature=0.0,
-)
+judge = ChatAnthropic(model="claude-3-5-sonnet-20241022", api_key="your-api-key", temperature=0.0)
 ```
 
-### Ollama (Local)
-
-```python
+```python Ollama (Local)
 from langchain_ollama import ChatOllama
-
-judge = ChatOllama(
-    model="llama3.1:8b",
-    temperature=0.0,
-)
+judge = ChatOllama(model="llama3.1:70b", temperature=0.0)
 ```
-
-## Structured vs Non-Structured Output
-
-### Structured Output
-
-Uses LangChain's structured output feature (recommended):
-
-```python
-metrics = Context.run(
-    MyRetriever,
-    model=judge,
-    use_structured_output=True,  # Uses .with_structured_output()
-)
-```
-
-**Pros**: More reliable parsing, better type safety
-**Cons**: Requires model support for structured output
-
-### Non-Structured Output
-
-Uses regex extraction from JSON blocks:
-
-```python
-metrics = Context.run(
-    MyRetriever,
-    model=judge,
-    use_structured_output=False,
-    bos_json_clause="```json",
-    eos_json_clause="```",
-)
-```
-
-**Pros**: Works with any model
-**Cons**: May have parsing failures
+</CodeGroup>
 
 ## Best Practices
 
 <AccordionGroup>
+  <Accordion title="Use Bayesian Mode for Small Sessions">
+    A session with 3 interactions gives a very uncertain mean. Bayesian mode expresses this with a wide CI, preventing overconfident conclusions.
+  </Accordion>
+
   <Accordion title="Provide Clear Context">
-    Include specific, actionable instructions in your context:
+    Include specific, actionable instructions:
     ```python
     context = """You are a support assistant for Acme Corp.
     Rules:
     1. Always greet customers by name if available
     2. Never discuss competitors
-    3. Escalate billing issues to human support
-    4. Response time SLA: 24 hours"""
+    3. Escalate billing issues to human support"""
     ```
   </Accordion>
 
@@ -301,27 +280,26 @@ metrics = Context.run(
     ```
   </Accordion>
 
-  <Accordion title="Use Temperature 0">
-    Set `temperature=0` for consistent, deterministic judgments:
+  <Accordion title="Weight Critical Interactions">
+    If some QA pairs test more important context rules, give them higher weights:
     ```python
-    judge = ChatGroq(model="...", temperature=0.0)
+    Batch(qa_id="policy_question",   ..., weight=0.6),  # High-stakes
+    Batch(qa_id="greeting",          ..., weight=0.2),
+    Batch(qa_id="general_question",  ..., weight=0.2),
     ```
-  </Accordion>
-
-  <Accordion title="Choose Appropriate Model">
-    Larger models provide better judgment quality:
-    - **Production**: GPT-4, Claude-3, Llama-3-70B
-    - **Testing**: Llama-3-8B, GPT-3.5
   </Accordion>
 </AccordionGroup>
 
 ## Next Steps
 
-<CardGroup cols={2}>
-  <Card title="Conversational Metric" icon="comments" href="/metrics/conversational">
-    Learn about dialogue quality evaluation
+<CardGroup cols={3}>
+  <Card title="Statistical Modes" icon="chart-line" href="/core-concepts/statistical-modes">
+    Frequentist vs Bayesian approaches
   </Card>
-  <Card title="Humanity Metric" icon="heart" href="/metrics/humanity">
-    Learn about emotional analysis
+  <Card title="Conversational Metric" icon="comments" href="/metrics/conversational">
+    Evaluate dialogue quality with Grice's maxims
+  </Card>
+  <Card title="Regulatory Metric" icon="scale-balanced" href="/metrics/regulatory">
+    Compliance against a regulatory corpus
   </Card>
 </CardGroup>

--- a/docs/metrics/conversational.mdx
+++ b/docs/metrics/conversational.mdx
@@ -1,11 +1,11 @@
 ---
 title: Conversational
-description: Evaluate dialogue quality using Grice's Maxims
+description: Evaluate dialogue quality using Grice's Maxims with session-level aggregation and pluggable statistical modes
 ---
 
 # Conversational Metric
 
-The Conversational metric evaluates dialogue quality using **Grice's Maxims** - principles of cooperative conversation that define effective communication.
+The Conversational metric evaluates dialogue quality using **Grice's Maxims** — principles of cooperative conversation that define effective communication. It accumulates scores across all interactions in a session and emits one session-level result, with optional uncertainty quantification via Bayesian mode.
 
 ## Overview
 
@@ -21,6 +21,8 @@ The metric assesses seven dimensions:
 | **Language** | Appropriateness of language style | 0-10 |
 | **Sensibleness** | Overall coherence and logic | 0-10 |
 
+Each dimension produces a session-level `ConversationalScore` with a `mean` and optional credible interval (`ci_low`, `ci_high`) in Bayesian mode. The `interactions` list preserves per-QA scores for debugging.
+
 ## Installation
 
 ```bash
@@ -30,37 +32,46 @@ uv add langchain-groq  # Or your preferred LLM provider
 
 ## Basic Usage
 
-```python
+<CodeGroup>
+```python Frequentist (default)
 from fair_forge.metrics.conversational import Conversational
 from langchain_groq import ChatGroq
 from your_retriever import MyRetriever
 
-# Initialize the judge model
-judge_model = ChatGroq(
-    model="llama-3.3-70b-versatile",
-    api_key="your-api-key",
-    temperature=0.0,
-)
+judge_model = ChatGroq(model="llama-3.3-70b-versatile", api_key="your-api-key", temperature=0.0)
 
-# Run the metric
+metrics = Conversational.run(MyRetriever, model=judge_model)
+
+for metric in metrics:
+    print(f"Session: {metric.session_id}  ({metric.n_interactions} interactions)")
+    print(f"  Quality:      {metric.conversational_quality_maxim.mean:.1f}/10")
+    print(f"  Memory:       {metric.conversational_memory.mean:.1f}/10")
+    print(f"  Sensibleness: {metric.conversational_sensibleness.mean:.1f}/10")
+
+    # Per-interaction breakdown
+    for interaction in metric.interactions:
+        print(f"  [{interaction.qa_id}] quality={interaction.quality_maxim:.1f} memory={interaction.memory:.1f}")
+```
+
+```python Bayesian
+from fair_forge.metrics.conversational import Conversational
+from fair_forge.statistical import BayesianMode
+from langchain_groq import ChatGroq
+from your_retriever import MyRetriever
+
+judge_model = ChatGroq(model="llama-3.3-70b-versatile", api_key="your-api-key", temperature=0.0)
+
 metrics = Conversational.run(
     MyRetriever,
     model=judge_model,
-    use_structured_output=True,
-    verbose=True,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
 )
 
-# Analyze results
 for metric in metrics:
-    print(f"QA ID: {metric.qa_id}")
-    print(f"Quality: {metric.conversational_quality_maxim}/10")
-    print(f"Quantity: {metric.conversational_quantity_maxim}/10")
-    print(f"Relation: {metric.conversational_relation_maxim}/10")
-    print(f"Manner: {metric.conversational_manner_maxim}/10")
-    print(f"Memory: {metric.conversational_memory}/10")
-    print(f"Language: {metric.conversational_language}/10")
-    print(f"Sensibleness: {metric.conversational_sensibleness}/10")
+    q = metric.conversational_quality_maxim
+    print(f"Quality: {q.mean:.1f}  [{q.ci_low:.1f}, {q.ci_high:.1f}]")
 ```
+</CodeGroup>
 
 ## Parameters
 
@@ -75,10 +86,50 @@ for metric in metrics:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| `statistical_mode` | `StatisticalMode` | `FrequentistMode()` | Statistical computation mode |
 | `use_structured_output` | `bool` | `False` | Use LangChain structured output |
 | `bos_json_clause` | `str` | `"```json"` | JSON block start marker |
 | `eos_json_clause` | `str` | `"```"` | JSON block end marker |
 | `verbose` | `bool` | `False` | Enable verbose logging |
+
+## Statistical Modes
+
+<Tabs>
+  <Tab title="Frequentist">
+    Returns a weighted mean per dimension. `ci_low` and `ci_high` are `None`.
+
+    ```python
+    metric.conversational_quality_maxim.mean   # 7.8
+    metric.conversational_quality_maxim.ci_low  # None
+    ```
+  </Tab>
+  <Tab title="Bayesian">
+    Bootstraps the weighted mean across interactions to produce a credible interval — useful when you have few interactions and want to express uncertainty honestly.
+
+    ```python
+    metric.conversational_quality_maxim.mean   # 7.8
+    metric.conversational_quality_maxim.ci_low  # 6.2
+    metric.conversational_quality_maxim.ci_high # 9.1
+    ```
+  </Tab>
+</Tabs>
+
+## Interaction Weights
+
+Each `Batch` can carry an optional `weight` to control its contribution to the session aggregate:
+
+```python
+Batch(qa_id="q1", query="...", assistant="...", ground_truth_assistant="...", weight=0.5),
+Batch(qa_id="q2", query="...", assistant="...", ground_truth_assistant="...", weight=0.3),
+Batch(qa_id="q3", query="...", assistant="...", ground_truth_assistant="...", weight=0.2),
+```
+
+| Case | Behavior |
+|------|----------|
+| All weights provided, sum = 1.0 | Used as-is |
+| All weights provided, sum ≠ 1.0 | Warning emitted, equal weights applied |
+| Some weights provided | Remaining weight split equally among unweighted interactions |
+| No weights provided | Equal weights (1/n each) |
 
 ## Output Schema
 
@@ -88,89 +139,76 @@ for metric in metrics:
 class ConversationalMetric(BaseMetric):
     session_id: str
     assistant_id: str
+    n_interactions: int                                    # Number of interactions evaluated
+    conversational_memory: ConversationalScore
+    conversational_language: ConversationalScore
+    conversational_quality_maxim: ConversationalScore
+    conversational_quantity_maxim: ConversationalScore
+    conversational_relation_maxim: ConversationalScore
+    conversational_manner_maxim: ConversationalScore
+    conversational_sensibleness: ConversationalScore
+    interactions: list[ConversationalInteraction]          # Per-QA scores
+```
+
+### ConversationalScore
+
+```python
+class ConversationalScore(BaseModel):
+    mean: float           # Session-level weighted mean
+    ci_low: float | None  # Lower credible bound — Bayesian mode only
+    ci_high: float | None # Upper credible bound — Bayesian mode only
+```
+
+### ConversationalInteraction
+
+```python
+class ConversationalInteraction(BaseModel):
     qa_id: str
-    conversational_memory: float          # 0-10
-    conversational_language: float        # 0-10
-    conversational_quality_maxim: float   # 0-10
-    conversational_quantity_maxim: float  # 0-10
-    conversational_relation_maxim: float  # 0-10
-    conversational_manner_maxim: float    # 0-10
-    conversational_sensibleness: float    # 0-10
-    conversational_insight: str           # Explanation
-    conversational_thinkings: str         # Judge reasoning
+    memory: float
+    language: float
+    quality_maxim: float
+    quantity_maxim: float
+    relation_maxim: float
+    manner_maxim: float
+    sensibleness: float
 ```
 
 ## Understanding Grice's Maxims
 
 ### Quality Maxim
-
 **Be truthful**: Don't say what you believe to be false or lack evidence for.
-
 ```
-High Score (8-10): "The capital of France is Paris." (Verifiable fact)
-Low Score (0-4): "France doesn't have a capital." (False information)
+High (8-10): "The capital of France is Paris." (Verifiable fact)
+Low  (0-4):  "France doesn't have a capital." (False)
 ```
 
 ### Quantity Maxim
-
 **Be informative**: Provide enough information, but not more than required.
-
 ```
-High Score (8-10): "Paris is the capital of France." (Just right)
-Low Score (0-4): "Paris." (Too brief) or "Paris is the capital, founded in 3rd century..." (Too much)
+High (8-10): "Paris is the capital of France."
+Low  (0-4):  "Paris." (Too brief) or a 3-paragraph essay (Too much)
 ```
 
 ### Relation Maxim
-
 **Be relevant**: Make your contribution relevant to the conversation.
-
 ```
-High Score (8-10): Q: "What's your return policy?" A: "Returns accepted within 30 days."
-Low Score (0-4): Q: "What's your return policy?" A: "Our company was founded in 1998."
+High (8-10): Q: "What's your return policy?" A: "Returns accepted within 30 days."
+Low  (0-4):  Q: "What's your return policy?" A: "Our company was founded in 1998."
 ```
 
 ### Manner Maxim
-
-**Be clear**: Avoid obscurity and ambiguity. Be brief and orderly.
-
+**Be clear**: Avoid obscurity and ambiguity.
 ```
-High Score (8-10): "You can return items within 30 days at any store location."
-Low Score (0-4): "So basically, if you want to, you could possibly maybe return the thing..."
-```
-
-### Memory
-
-**Recall context**: Reference previous parts of the conversation appropriately.
-
-```
-High Score (8-10): References customer's earlier question or stated preferences
-Low Score (0-4): Asks for information already provided in the conversation
-```
-
-### Language
-
-**Appropriate style**: Match language register to the context.
-
-```
-High Score (8-10): Professional tone for business, friendly for casual
-Low Score (0-4): Overly casual in formal context, or overly stiff in casual
-```
-
-### Sensibleness
-
-**Overall coherence**: Response makes logical sense in context.
-
-```
-High Score (8-10): Logically connected, coherent response
-Low Score (0-4): Non-sequiturs, contradictions, or nonsensical content
+High (8-10): "You can return items within 30 days at any store location."
+Low  (0-4):  "So basically, if you want to, you could possibly maybe return the thing..."
 ```
 
 ## Complete Example
 
 ```python
 import os
-import numpy as np
 from fair_forge.metrics.conversational import Conversational
+from fair_forge.statistical import BayesianMode
 from fair_forge.core.retriever import Retriever
 from fair_forge.schemas.common import Dataset, Batch
 from langchain_groq import ChatGroq
@@ -187,135 +225,82 @@ class ConversationalRetriever(Retriever):
                     Batch(
                         qa_id="q1",
                         query="Hi, I need help with my order.",
-                        assistant="Hello! I'd be happy to help with your order. Could you please provide your order number?",
+                        assistant="Hello! I'd be happy to help. Could you share your order number?",
                         ground_truth_assistant="Greet and ask for order number.",
                         observation="Opening interaction - should be professional and helpful",
                     ),
                     Batch(
                         qa_id="q2",
                         query="It's ORDER-12345. I haven't received it yet.",
-                        assistant="Thank you! I found order ORDER-12345. It was shipped on Monday and is currently in transit. Expected delivery is Friday.",
+                        assistant="Thank you! ORDER-12345 was shipped Monday, expected Friday.",
                         ground_truth_assistant="Find order, provide shipping status and ETA.",
-                        observation="Should remember the order number and provide relevant info",
                     ),
                     Batch(
                         qa_id="q3",
                         query="Can you change the delivery address?",
-                        assistant="I'd be glad to help with that. For security, please confirm your email address first.",
+                        assistant="For security, please confirm your email address first.",
                         ground_truth_assistant="Offer to help, verify identity first.",
-                        observation="Should acknowledge request and follow security protocol",
                     ),
                 ]
             )
         ]
 
-# Initialize judge
-judge = ChatGroq(
-    model="llama-3.3-70b-versatile",
-    api_key=os.getenv("GROQ_API_KEY"),
-    temperature=0.0,
-)
+judge = ChatGroq(model="llama-3.3-70b-versatile", api_key=os.getenv("GROQ_API_KEY"), temperature=0.0)
 
-# Run evaluation
 metrics = Conversational.run(
     ConversationalRetriever,
     model=judge,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
     use_structured_output=True,
-    verbose=True,
 )
 
-# Analyze results
-print("Conversational Quality Evaluation")
-print("=" * 60)
-
 for metric in metrics:
-    print(f"\nQA ID: {metric.qa_id}")
-    print(f"  Memory: {metric.conversational_memory}/10")
-    print(f"  Language: {metric.conversational_language}/10")
-    print(f"  Quality: {metric.conversational_quality_maxim}/10")
-    print(f"  Quantity: {metric.conversational_quantity_maxim}/10")
-    print(f"  Relation: {metric.conversational_relation_maxim}/10")
-    print(f"  Manner: {metric.conversational_manner_maxim}/10")
-    print(f"  Sensibleness: {metric.conversational_sensibleness}/10")
-    print(f"  Insight: {metric.conversational_insight[:100]}...")
+    print(f"Session: {metric.session_id}  ({metric.n_interactions} interactions)")
+    print()
 
-# Summary statistics
-print("\n" + "=" * 60)
-print("Summary Statistics")
-print("=" * 60)
+    dimensions = [
+        ("Quality",      metric.conversational_quality_maxim),
+        ("Quantity",     metric.conversational_quantity_maxim),
+        ("Relation",     metric.conversational_relation_maxim),
+        ("Manner",       metric.conversational_manner_maxim),
+        ("Memory",       metric.conversational_memory),
+        ("Language",     metric.conversational_language),
+        ("Sensibleness", metric.conversational_sensibleness),
+    ]
 
-dimensions = [
-    ('Quality', [m.conversational_quality_maxim for m in metrics]),
-    ('Quantity', [m.conversational_quantity_maxim for m in metrics]),
-    ('Relation', [m.conversational_relation_maxim for m in metrics]),
-    ('Manner', [m.conversational_manner_maxim for m in metrics]),
-    ('Memory', [m.conversational_memory for m in metrics]),
-    ('Language', [m.conversational_language for m in metrics]),
-    ('Sensibleness', [m.conversational_sensibleness for m in metrics]),
-]
+    for name, score in dimensions:
+        ci = f"  [{score.ci_low:.1f}, {score.ci_high:.1f}]" if score.ci_low is not None else ""
+        print(f"  {name:<14} {score.mean:.1f}/10{ci}")
 
-for name, scores in dimensions:
-    print(f"{name}: Mean={np.mean(scores):.2f}, Min={np.min(scores):.0f}, Max={np.max(scores):.0f}")
-```
-
-## Visualization
-
-### Radar Chart
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-
-categories = ['Quality', 'Quantity', 'Relation', 'Manner', 'Memory', 'Language', 'Sensibleness']
-
-# Calculate averages
-avg_scores = {
-    'Quality': np.mean([m.conversational_quality_maxim for m in metrics]),
-    'Quantity': np.mean([m.conversational_quantity_maxim for m in metrics]),
-    'Relation': np.mean([m.conversational_relation_maxim for m in metrics]),
-    'Manner': np.mean([m.conversational_manner_maxim for m in metrics]),
-    'Memory': np.mean([m.conversational_memory for m in metrics]),
-    'Language': np.mean([m.conversational_language for m in metrics]),
-    'Sensibleness': np.mean([m.conversational_sensibleness for m in metrics]),
-}
-
-values = [avg_scores[cat] / 10 for cat in categories]  # Normalize to 0-1
-values += values[:1]  # Close the polygon
-
-angles = [n / float(len(categories)) * 2 * np.pi for n in range(len(categories))]
-angles += angles[:1]
-
-fig, ax = plt.subplots(figsize=(8, 8), subplot_kw=dict(polar=True))
-ax.plot(angles, values, 'o-', linewidth=2, color='steelblue')
-ax.fill(angles, values, alpha=0.25, color='steelblue')
-ax.set_xticks(angles[:-1])
-ax.set_xticklabels(categories)
-ax.set_ylim(0, 1)
-ax.set_title('Conversational Quality Scores')
-plt.show()
+    print()
+    print("  Per-interaction breakdown:")
+    for interaction in metric.interactions:
+        print(f"    [{interaction.qa_id}] quality={interaction.quality_maxim:.1f}  memory={interaction.memory:.1f}  manner={interaction.manner_maxim:.1f}")
 ```
 
 ## Score Interpretation
 
 | Score Range | Interpretation |
 |-------------|----------------|
-| 8-10 | Excellent - High-quality dialogue |
-| 6-8 | Good - Meets expectations with minor issues |
-| 4-6 | Moderate - Noticeable quality issues |
-| 2-4 | Poor - Significant problems |
-| 0-2 | Very Poor - Fails basic criteria |
+| 8-10 | Excellent — high-quality dialogue |
+| 6-8 | Good — meets expectations with minor issues |
+| 4-6 | Moderate — noticeable quality issues |
+| 2-4 | Poor — significant problems |
+| 0-2 | Very poor — fails basic criteria |
 
 ## Best Practices
 
 <AccordionGroup>
+  <Accordion title="Use Bayesian Mode for Small Sessions">
+    If a session has fewer than 5-10 interactions, the frequentist mean can be misleading. Bayesian mode shows a CI, making it clear when more data is needed.
+  </Accordion>
+
   <Accordion title="Include Observations">
-    Add `observation` field to guide evaluation:
+    Add `observation` to guide the judge on what to evaluate:
     ```python
     Batch(
-        qa_id="q1",
-        query="...",
-        assistant="...",
-        observation="This is a follow-up question - assistant should remember previous context",
+        qa_id="q2",
+        observation="Follow-up — assistant should remember the order number from q1",
     )
     ```
   </Accordion>
@@ -323,29 +308,22 @@ plt.show()
   <Accordion title="Test Multi-Turn Conversations">
     Include sequences that test memory:
     ```python
-    [
-        Batch(qa_id="q1", query="My name is John...", ...),
-        Batch(qa_id="q2", query="What's my name?", ...),  # Should remember
-    ]
+    Batch(qa_id="q1", query="My name is John..."),
+    Batch(qa_id="q2", query="What's my name?"),  # Should remember
     ```
-  </Accordion>
-
-  <Accordion title="Vary Conversation Types">
-    Include different interaction styles:
-    - Factual questions
-    - Clarification requests
-    - Complex multi-part queries
-    - Follow-up questions
   </Accordion>
 </AccordionGroup>
 
 ## Next Steps
 
-<CardGroup cols={2}>
-  <Card title="Humanity Metric" icon="heart" href="/metrics/humanity">
-    Learn about emotional analysis
+<CardGroup cols={3}>
+  <Card title="Statistical Modes" icon="chart-line" href="/core-concepts/statistical-modes">
+    Frequentist vs Bayesian — when each matters
   </Card>
-  <Card title="BestOf Metric" icon="trophy" href="/metrics/best-of">
-    Learn about assistant comparison
+  <Card title="Context Metric" icon="bullseye" href="/metrics/context">
+    Evaluate context alignment
+  </Card>
+  <Card title="Humanity Metric" icon="heart" href="/metrics/humanity">
+    Emotional analysis of responses
   </Card>
 </CardGroup>

--- a/docs/metrics/regulatory.mdx
+++ b/docs/metrics/regulatory.mdx
@@ -1,19 +1,18 @@
 ---
 title: Regulatory
-description: Evaluate AI responses against regulatory compliance using RAG-based retrieval and reranking
+description: Evaluate AI responses against regulatory compliance using RAG-based retrieval, reranking, and pluggable statistical modes
 ---
 
 # Regulatory Metric
 
-The Regulatory metric evaluates whether AI assistant responses comply with a regulatory corpus (e.g., company policies, legal frameworks, compliance documents). It uses embedding-based retrieval to find relevant regulations and a reranker to detect contradictions.
+The Regulatory metric evaluates whether AI assistant responses comply with a regulatory corpus (e.g., company policies, legal frameworks, compliance documents). It accumulates per-interaction compliance scores and emits one session-level result. The `interactions` list preserves per-QA verdicts for auditing.
 
 ## Overview
 
-This metric evaluates:
-
-- **Compliance Score**: Ratio of supporting vs. contradicting regulatory chunks (0.0-1.0)
-- **Verdict**: COMPLIANT, NON_COMPLIANT, or IRRELEVANT
-- **Chunk Analysis**: Detailed breakdown of which regulations support or contradict the response
+- **Compliance Score**: Weighted mean of per-interaction scores across the session (0.0–1.0)
+- **Verdict**: Session-level `COMPLIANT`, `NON_COMPLIANT`, or `IRRELEVANT` — derived directly from the aggregated score for consistency
+- **Per-interaction detail**: Each QA pair's verdict, chunks, and insight accessible via `interactions`
+- **Bayesian mode**: Bootstrapped credible interval around the session compliance score
 
 ### How It Works
 
@@ -21,10 +20,23 @@ This metric evaluates:
 1. Load regulatory corpus (markdown files)
 2. Chunk documents with configurable size/overlap
 3. For each interaction:
-   a. Retrieve relevant chunks using embeddings (user query + agent response)
-   b. Rerank chunks to detect support/contradiction
-   c. Compute compliance score and verdict
+   a. Retrieve relevant chunks via embeddings (user query + agent response)
+   b. Rerank chunks → classify as SUPPORTS or CONTRADICTS
+   c. compliance_score = supporting / (supporting + contradicting)
+   d. verdict = COMPLIANT / NON_COMPLIANT / IRRELEVANT
+4. Session aggregate: weighted mean of per-interaction scores
+5. Session verdict derived from the aggregated score
 ```
+
+### How the Verdict Is Determined
+
+| Condition | Verdict |
+|-----------|---------|
+| All interactions IRRELEVANT | `IRRELEVANT` |
+| `compliance_score >= compliance_threshold` | `COMPLIANT` |
+| `compliance_score < compliance_threshold` | `NON_COMPLIANT` |
+
+The session `verdict` is always derived from the session `compliance_score` — they always agree.
 
 <Note>
 The metric uses **Qwen3-Embedding** for semantic retrieval and **Qwen3-Reranker** for contradiction detection. Both models run locally using HuggingFace Transformers.
@@ -36,32 +48,51 @@ The metric uses **Qwen3-Embedding** for semantic retrieval and **Qwen3-Reranker*
 uv add "alquimia-fair-forge[regulatory]"
 ```
 
-This installs PyTorch and Accelerate for running the embedding and reranker models.
-
 ## Basic Usage
 
-```python
+<CodeGroup>
+```python Frequentist (default)
 from fair_forge.connectors import LocalCorpusConnector
 from fair_forge.metrics.regulatory import Regulatory
 from your_retriever import ConversationRetriever
 
-# Load regulatory corpus from local directory
 corpus_connector = LocalCorpusConnector("path/to/regulations/")
 
-# Run evaluation
+metrics = Regulatory.run(ConversationRetriever, corpus_connector=corpus_connector)
+
+for metric in metrics:
+    print(f"Session: {metric.session_id}")
+    print(f"  Verdict:           {metric.verdict}")
+    print(f"  Compliance score:  {metric.compliance_score:.1%}")
+    print(f"  Interactions:      {metric.n_interactions}")
+    print(f"  Total supporting:  {metric.total_supporting_chunks}")
+    print(f"  Total contradicting: {metric.total_contradicting_chunks}")
+
+    for interaction in metric.interactions:
+        icon = {"COMPLIANT": "✅", "NON_COMPLIANT": "❌", "IRRELEVANT": "⚠️"}[interaction.verdict]
+        print(f"  {icon} [{interaction.qa_id}] {interaction.verdict}  score={interaction.compliance_score:.1%}")
+```
+
+```python Bayesian
+from fair_forge.connectors import LocalCorpusConnector
+from fair_forge.metrics.regulatory import Regulatory
+from fair_forge.statistical import BayesianMode
+from your_retriever import ConversationRetriever
+
+corpus_connector = LocalCorpusConnector("path/to/regulations/")
+
 metrics = Regulatory.run(
     ConversationRetriever,
     corpus_connector=corpus_connector,
-    verbose=True,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
 )
 
-# Analyze results
 for metric in metrics:
-    print(f"QA {metric.qa_id}: {metric.verdict}")
-    print(f"  Compliance: {metric.compliance_score:.1%}")
-    print(f"  Supporting: {metric.supporting_chunks}, Contradicting: {metric.contradicting_chunks}")
-    print(f"  Insight: {metric.insight}")
+    print(f"Compliance: {metric.compliance_score:.1%}  "
+          f"[{metric.compliance_score_ci_low:.1%}, {metric.compliance_score_ci_high:.1%}]")
+    print(f"Verdict: {metric.verdict}")
 ```
+</CodeGroup>
 
 ## Parameters
 
@@ -70,56 +101,126 @@ for metric in metrics:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `retriever` | `Type[Retriever]` | Data source class returning conversations to evaluate |
-| `corpus_connector` | `CorpusConnector` | Connector for loading regulatory documents (local or LakeFS) |
+| `corpus_connector` | `CorpusConnector` | Connector for loading regulatory documents |
 
 ### Optional Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| `statistical_mode` | `StatisticalMode` | `FrequentistMode()` | Statistical computation mode |
 | `embedding_model` | `str` | `"Qwen/Qwen3-Embedding-0.6B"` | HuggingFace model for embeddings |
 | `reranker_model` | `str` | `"Qwen/Qwen3-Reranker-0.6B"` | HuggingFace model for reranking |
 | `chunk_size` | `int` | `1000` | Characters per chunk |
 | `chunk_overlap` | `int` | `100` | Character overlap between chunks |
 | `top_k` | `int` | `10` | Maximum chunks to retrieve per query |
-| `similarity_threshold` | `float` | `0.3` | Minimum cosine similarity for retrieval (0-1) |
-| `contradiction_threshold` | `float` | `0.6` | Score below which a chunk contradicts (0-1) |
-| `compliance_threshold` | `float` | `0.5` | Minimum compliance score to consider a response compliant (0-1) |
+| `similarity_threshold` | `float` | `0.3` | Minimum cosine similarity for retrieval |
+| `contradiction_threshold` | `float` | `0.6` | Reranker score below which a chunk is classified as contradicting |
+| `compliance_threshold` | `float` | `0.5` | Minimum session compliance score to emit COMPLIANT verdict |
 | `max_length` | `int` | `8192` | Maximum token length for models |
 | `batch_size` | `int` | `32` | Batch size for embedding computation |
 | `verbose` | `bool` | `False` | Enable verbose logging |
 
-### Model Options
+## Statistical Modes
 
-You can use larger models for better quality:
+<Tabs>
+  <Tab title="Frequentist">
+    Returns the weighted mean of per-interaction compliance scores. CI fields are `None`.
 
-| Model Size | Embedding Model | Reranker Model |
-|------------|-----------------|----------------|
-| Small (0.6B) | `Qwen/Qwen3-Embedding-0.6B` | `Qwen/Qwen3-Reranker-0.6B` |
-| Medium (4B) | `Qwen/Qwen3-Embedding-4B` | `Qwen/Qwen3-Reranker-4B` |
-| Large (8B) | `Qwen/Qwen3-Embedding-8B` | `Qwen/Qwen3-Reranker-8B` |
+    ```python
+    metric.compliance_score          # 0.78
+    metric.compliance_score_ci_low   # None
+    metric.compliance_score_ci_high  # None
+    ```
+  </Tab>
+  <Tab title="Bayesian">
+    Bootstraps the weighted mean to produce a credible interval — useful for communicating uncertainty when a session has few interactions.
+
+    ```python
+    metric.compliance_score          # 0.78
+    metric.compliance_score_ci_low   # 0.58
+    metric.compliance_score_ci_high  # 0.93
+    ```
+
+    A wide CI (e.g. [0.30, 0.95]) means the true compliance rate is highly uncertain — collect more data before making compliance decisions.
+  </Tab>
+</Tabs>
+
+## Interaction Weights
+
+Each `Batch` can carry an optional `weight` to control its contribution to the session aggregate:
+
+```python
+# Weight high-risk interactions more heavily
+Batch(qa_id="billing_dispute",  ..., weight=0.5),   # Critical compliance area
+Batch(qa_id="general_inquiry",  ..., weight=0.3),
+Batch(qa_id="small_talk",       ..., weight=0.2),
+```
+
+| Case | Behavior |
+|------|----------|
+| All weights provided, sum = 1.0 | Used as-is |
+| All weights provided, sum ≠ 1.0 | Warning emitted, equal weights applied |
+| Some weights provided | Remaining weight split equally among unweighted |
+| No weights provided | Equal weights (1/n each) |
+
+## Output Schema
+
+### RegulatoryMetric
+
+```python
+class RegulatoryMetric(BaseMetric):
+    session_id: str
+    assistant_id: str
+    n_interactions: int                    # Number of interactions evaluated
+    compliance_score: float                # Weighted mean compliance score (0.0-1.0)
+    compliance_score_ci_low: float | None  # Lower credible bound — Bayesian only
+    compliance_score_ci_high: float | None # Upper credible bound — Bayesian only
+    verdict: Literal["COMPLIANT", "NON_COMPLIANT", "IRRELEVANT"]
+    total_supporting_chunks: int           # Sum across all interactions
+    total_contradicting_chunks: int        # Sum across all interactions
+    interactions: list[RegulatoryInteraction]  # Per-QA detail
+```
+
+### RegulatoryInteraction
+
+```python
+class RegulatoryInteraction(BaseModel):
+    qa_id: str
+    query: str
+    assistant: str
+    compliance_score: float                # supporting / (supporting + contradicting)
+    verdict: Literal["COMPLIANT", "NON_COMPLIANT", "IRRELEVANT"]
+    supporting_chunks: int
+    contradicting_chunks: int
+    retrieved_chunks: list[RegulatoryChunk]  # Chunk-level evidence
+    insight: str                             # Human-readable explanation
+```
+
+### RegulatoryChunk
+
+```python
+class RegulatoryChunk(BaseModel):
+    text: str              # Chunk content
+    source: str            # Source document filename
+    chunk_index: int       # Position in source document
+    similarity: float      # Cosine similarity from retrieval (0-1)
+    reranker_score: float  # Reranker score (higher = supports)
+    verdict: Literal["SUPPORTS", "CONTRADICTS"]
+```
 
 ## Corpus Connectors
 
 ### LocalCorpusConnector
 
-Load regulatory documents from a local directory:
-
 ```python
 from fair_forge.connectors import LocalCorpusConnector
 
-# Load all .md files from directory
 connector = LocalCorpusConnector("path/to/corpus/")
-
-# Verify documents load correctly
 documents = connector.load_documents()
 print(f"Loaded {len(documents)} documents")
-for doc in documents:
-    print(f"  - {doc.source}: {len(doc.text)} chars")
 ```
 
 ### LakeFSCorpusConnector
-
-Load regulatory documents from LakeFS storage:
 
 ```python
 from fair_forge.connectors.lakefs import LakeFSCorpusConnector
@@ -132,117 +233,18 @@ connector = LakeFSCorpusConnector(
     corpus_prefix="compliance/",
     branch_name="main",
 )
-
-documents = connector.load_documents()
 ```
-
-## Output Schema
-
-### RegulatoryMetric
-
-```python
-class RegulatoryMetric(BaseMetric):
-    session_id: str                    # Session identifier
-    assistant_id: str                  # Assistant identifier
-    qa_id: str                         # Interaction identifier
-    query: str                         # User query
-    assistant: str                     # Assistant response
-    compliance_score: float            # 0.0-1.0 (supporting / total chunks)
-    verdict: Literal["COMPLIANT", "NON_COMPLIANT", "IRRELEVANT"]
-    supporting_chunks: int             # Count of supporting chunks
-    contradicting_chunks: int          # Count of contradicting chunks
-    retrieved_chunks: list[RegulatoryChunk]  # Detailed chunk analysis
-    insight: str                       # Human-readable explanation
-```
-
-### RegulatoryChunk
-
-```python
-class RegulatoryChunk(BaseModel):
-    text: str              # Chunk content
-    source: str            # Source document filename
-    chunk_index: int       # Position in source document
-    similarity: float      # Cosine similarity from retrieval (0-1)
-    reranker_score: float  # Reranker score (0-1, higher = supports)
-    verdict: Literal["SUPPORTS", "CONTRADICTS"]
-```
-
-## Verdicts
-
-| Verdict | Condition | Compliance Score |
-|---------|-----------|------------------|
-| **COMPLIANT** | `compliance_score >= compliance_threshold` | `supporting / (supporting + contradicting)` |
-| **NON_COMPLIANT** | `compliance_score < compliance_threshold` or all contradicting | `supporting / (supporting + contradicting)` |
-| **IRRELEVANT** | No chunks retrieved | `compliance_threshold` (neutral) |
-
-## Data Requirements
-
-Create a Retriever that returns conversations to evaluate:
-
-```python
-from fair_forge.core.retriever import Retriever
-from fair_forge.schemas.common import Dataset, Batch
-
-class CustomerServiceRetriever(Retriever):
-    def load_dataset(self) -> list[Dataset]:
-        return [
-            Dataset(
-                session_id="session_001",
-                assistant_id="support_bot",
-                language="english",
-                context="Customer service compliance evaluation",
-                conversation=[
-                    Batch(
-                        qa_id="qa_001",
-                        query="Stop calling me at midnight!",
-                        assistant="I apologize for the inconvenience. I've added you to our do-not-call list.",
-                        ground_truth_assistant="Honor customer request to stop calls",
-                    ),
-                    Batch(
-                        qa_id="qa_002",
-                        query="I want a refund for my purchase from 2 months ago",
-                        assistant="Our policy allows refunds within 30 days. For older purchases, I can offer store credit.",
-                        ground_truth_assistant="Explain 30-day policy, offer alternatives",
-                    ),
-                ],
-            ),
-        ]
-```
-
-## Regulatory Corpus Format
-
-Create markdown files in your corpus directory. Each file should contain regulations, policies, or compliance rules:
-
-```markdown
-# Call Center Policy
-
-## Do-Not-Call Regulations
-
-### Customer Rights
-- All customers have the right to request removal from call lists at any time
-- Requests must be honored within 24 hours of receipt
-- No calls should be made between 9:00 PM and 8:00 AM local time
-
-### Record Keeping
-- All do-not-call requests must be logged with timestamp
-- Records must be maintained for a minimum of 5 years
-```
-
-<Note>
-Place multiple `.md` files in the corpus directory. The metric will load all of them, chunk the text, and use them for compliance checking.
-</Note>
 
 ## Complete Example
 
 ```python
 import os
-from pathlib import Path
 from fair_forge.connectors import LocalCorpusConnector
 from fair_forge.core.retriever import Retriever
 from fair_forge.metrics.regulatory import Regulatory
+from fair_forge.statistical import BayesianMode
 from fair_forge.schemas.common import Dataset, Batch
 
-# Create retriever with test conversations
 class ComplianceRetriever(Retriever):
     def load_dataset(self) -> list[Dataset]:
         return [
@@ -255,65 +257,65 @@ class ComplianceRetriever(Retriever):
                     Batch(
                         qa_id="qa_001",
                         query="I don't want any more calls from you!",
-                        assistant="I understand. I've immediately added your number to our do-not-call list. You won't receive any further calls from us.",
+                        assistant="I've immediately added your number to our do-not-call list.",
                         ground_truth_assistant="Add to do-not-call list",
+                        weight=0.6,  # High-stakes interaction
                     ),
                     Batch(
                         qa_id="qa_002",
                         query="Can I get a refund? I bought this 45 days ago.",
-                        assistant="Our standard refund policy is 30 days. Since your purchase is outside this window, I can offer you store credit or an exchange instead.",
+                        assistant="Our standard refund policy is 30 days. I can offer store credit instead.",
                         ground_truth_assistant="Explain 30-day limit, offer alternatives",
+                        weight=0.4,
                     ),
                 ],
             ),
         ]
 
-# Load regulatory corpus
 corpus_connector = LocalCorpusConnector("./regulations/")
 
-# Run evaluation with custom thresholds
 metrics = Regulatory.run(
     ComplianceRetriever,
     corpus_connector=corpus_connector,
-    embedding_model="Qwen/Qwen3-Embedding-0.6B",
-    reranker_model="Qwen/Qwen3-Reranker-0.6B",
-    chunk_size=500,
-    chunk_overlap=50,
-    top_k=5,
-    similarity_threshold=0.3,
-    contradiction_threshold=0.6,
+    statistical_mode=BayesianMode(mc_samples=5000, ci_level=0.95),
+    compliance_threshold=0.5,
     verbose=True,
 )
 
-# Display results
-print("Regulatory Compliance Results")
-print("=" * 60)
-
 for metric in metrics:
-    status_icon = {"COMPLIANT": "✅", "NON_COMPLIANT": "❌", "IRRELEVANT": "⚠️"}
-    print(f"\n{status_icon[metric.verdict]} QA: {metric.qa_id}")
-    print(f"   Query: {metric.query[:50]}...")
-    print(f"   Verdict: {metric.verdict}")
-    print(f"   Score: {metric.compliance_score:.1%}")
-    print(f"   Chunks: {metric.supporting_chunks} supporting, {metric.contradicting_chunks} contradicting")
-    print(f"   Insight: {metric.insight}")
+    print(f"Session: {metric.session_id}")
+    ci = f"  [{metric.compliance_score_ci_low:.1%}, {metric.compliance_score_ci_high:.1%}]" \
+         if metric.compliance_score_ci_low is not None else ""
+    print(f"  Compliance: {metric.compliance_score:.1%}{ci}")
+    print(f"  Verdict:    {metric.verdict}")
+    print(f"  Evidence:   {metric.total_supporting_chunks} supporting, {metric.total_contradicting_chunks} contradicting")
+    print()
 
-    # Show retrieved chunks
-    if metric.retrieved_chunks:
-        print(f"   Retrieved chunks:")
-        for chunk in metric.retrieved_chunks[:3]:  # Show top 3
-            print(f"     [{chunk.verdict}] {chunk.source} (sim={chunk.similarity:.2f}, rerank={chunk.reranker_score:.2f})")
-            print(f"       {chunk.text[:80]}...")
+    icon = {"COMPLIANT": "✅", "NON_COMPLIANT": "❌", "IRRELEVANT": "⚠️"}
+    for interaction in metric.interactions:
+        print(f"  {icon[interaction.verdict]} [{interaction.qa_id}] {interaction.verdict}  score={interaction.compliance_score:.1%}")
+        print(f"     {interaction.insight}")
+        for chunk in interaction.retrieved_chunks[:2]:
+            print(f"     [{chunk.verdict}] {chunk.source}  sim={chunk.similarity:.2f}  rerank={chunk.reranker_score:.2f}")
+```
 
-# Summary statistics
-compliant = sum(1 for m in metrics if m.verdict == "COMPLIANT")
-non_compliant = sum(1 for m in metrics if m.verdict == "NON_COMPLIANT")
-irrelevant = sum(1 for m in metrics if m.verdict == "IRRELEVANT")
-avg_score = sum(m.compliance_score for m in metrics) / len(metrics)
+## Regulatory Corpus Format
 
-print(f"\n{'=' * 60}")
-print(f"Summary: {compliant} compliant, {non_compliant} non-compliant, {irrelevant} irrelevant")
-print(f"Average compliance score: {avg_score:.1%}")
+Create markdown files in your corpus directory:
+
+```markdown
+# Call Center Policy
+
+## Do-Not-Call Regulations
+
+### Customer Rights
+- All customers have the right to request removal from call lists at any time
+- Requests must be honored within 24 hours of receipt
+- No calls between 9:00 PM and 8:00 AM local time
+
+## Refund Policy
+- Full refunds available within 30 days of purchase with original receipt
+- Refunds processed within 5-7 business days
 ```
 
 ## Interpretation
@@ -322,103 +324,45 @@ print(f"Average compliance score: {avg_score:.1%}")
 
 | Score Range | Interpretation |
 |-------------|----------------|
-| **0.9 - 1.0** | Excellent - Strong regulatory support |
-| **0.7 - 0.9** | Good - Mostly compliant |
-| **0.5 - 0.7** | Moderate - Mixed signals, review recommended |
-| **0.3 - 0.5** | Poor - Potential compliance issues |
-| **0.0 - 0.3** | Critical - Clear regulatory violations |
+| 0.9–1.0 | Excellent — strong regulatory support |
+| 0.7–0.9 | Good — mostly compliant |
+| 0.5–0.7 | Moderate — mixed signals, review recommended |
+| 0.3–0.5 | Poor — potential compliance issues |
+| 0.0–0.3 | Critical — clear regulatory violations |
 
-### Threshold Tuning
+### Model Options
+
+| Size | Embedding Model | Reranker Model |
+|------|-----------------|----------------|
+| Small (0.6B) | `Qwen/Qwen3-Embedding-0.6B` | `Qwen/Qwen3-Reranker-0.6B` |
+| Medium (4B) | `Qwen/Qwen3-Embedding-4B` | `Qwen/Qwen3-Reranker-4B` |
+| Large (8B) | `Qwen/Qwen3-Embedding-8B` | `Qwen/Qwen3-Reranker-8B` |
+
+## Threshold Tuning
 
 <AccordionGroup>
   <Accordion title="Similarity Threshold (0.3 default)">
     Controls which chunks are retrieved based on semantic similarity.
-
     - **Lower (0.2)**: Retrieves more chunks, may include less relevant ones
-    - **Default (0.3)**: Balanced retrieval
     - **Higher (0.5)**: Stricter, only highly relevant chunks
 
     Lower this if you're getting too many IRRELEVANT verdicts.
   </Accordion>
 
   <Accordion title="Contradiction Threshold (0.6 default)">
-    Controls how the reranker classifies chunks as supporting or contradicting.
-
-    - **Lower (0.4)**: Stricter - more chunks classified as contradicting
-    - **Default (0.6)**: Balanced classification
-    - **Higher (0.8)**: Lenient - only clear contradictions flagged
+    Controls how the reranker classifies chunks as SUPPORTS or CONTRADICTS.
+    - **Lower (0.4)**: Stricter — more chunks classified as contradicting
+    - **Higher (0.8)**: Lenient — only clear contradictions flagged
 
     Lower this for stricter compliance checking.
   </Accordion>
 
   <Accordion title="Compliance Threshold (0.5 default)">
-    Controls the minimum compliance score required to mark a response as COMPLIANT.
+    Minimum session compliance score to emit a COMPLIANT verdict.
+    - **Lower (0.3)**: Lenient — sessions pass with fewer supporting chunks
+    - **Higher (0.7)**: Strict — requires clear majority of supporting evidence
 
-    - **Lower (0.3)**: Lenient - responses with fewer supporting chunks still pass
-    - **Default (0.5)**: Balanced - at least half of retrieved chunks must support
-    - **Higher (0.7)**: Strict - requires clear majority of supporting chunks
-
-    Raise this for stricter compliance requirements.
-  </Accordion>
-
-  <Accordion title="Chunk Size (1000 default)">
-    Controls the size of text chunks from regulatory documents.
-
-    - **Smaller (500)**: More granular matching, better for short regulations
-    - **Default (1000)**: Good balance
-    - **Larger (2000)**: Better context, but may mix multiple regulations
-  </Accordion>
-</AccordionGroup>
-
-## Use Cases
-
-<CardGroup cols={2}>
-  <Card title="Financial Compliance" icon="building-columns">
-    Verify AI responses comply with banking regulations, KYC requirements, and financial advice rules
-  </Card>
-  <Card title="Healthcare HIPAA" icon="hospital">
-    Ensure patient data handling follows HIPAA guidelines and medical advice stays within scope
-  </Card>
-  <Card title="Call Center Policies" icon="headset">
-    Check customer service responses against company policies and consumer protection laws
-  </Card>
-  <Card title="Legal Compliance" icon="scale-balanced">
-    Validate AI-generated legal content against jurisdiction-specific regulations
-  </Card>
-</CardGroup>
-
-## Best Practices
-
-<AccordionGroup>
-  <Accordion title="Structure Your Regulatory Corpus">
-    - Use clear headings and sections in markdown files
-    - Group related regulations in the same file
-    - Use bullet points for specific rules
-    - Include both requirements and prohibited actions
-  </Accordion>
-
-  <Accordion title="Tune Chunk Size for Your Domain">
-    - Short, specific regulations: Use smaller chunks (500 chars)
-    - Long, contextual policies: Use larger chunks (1500-2000 chars)
-    - Overlap should be 10-20% of chunk size
-  </Accordion>
-
-  <Accordion title="Choose Appropriate Thresholds">
-    - **High-stakes compliance** (legal, medical): Lower contradiction threshold (0.4-0.5)
-    - **General policies**: Default thresholds work well
-    - **Broad guidelines**: Higher thresholds (0.7) to reduce false positives
-  </Accordion>
-
-  <Accordion title="Use Larger Models for Better Accuracy">
-    The 4B and 8B models provide better semantic understanding:
-    ```python
-    metrics = Regulatory.run(
-        retriever,
-        corpus_connector=connector,
-        embedding_model="Qwen/Qwen3-Embedding-4B",
-        reranker_model="Qwen/Qwen3-Reranker-4B",
-    )
-    ```
+    Raise this for high-stakes regulatory environments.
   </Accordion>
 </AccordionGroup>
 
@@ -426,53 +370,47 @@ print(f"Average compliance score: {avg_score:.1%}")
 
 <AccordionGroup>
   <Accordion title="Getting Too Many IRRELEVANT Verdicts">
-    **Cause**: Similarity threshold too high or corpus doesn't cover the topics.
-
-    **Solution**:
-    - Lower `similarity_threshold` to 0.2 or 0.25
-    - Verify corpus contains relevant regulations
-    - Check corpus is being loaded: `connector.load_documents()`
-    - Try smaller chunk sizes for more granular matching
+    Lower `similarity_threshold` to 0.2 or verify the corpus covers the topics being discussed.
   </Accordion>
 
   <Accordion title="Most Responses Marked NON_COMPLIANT">
-    **Cause**: Contradiction threshold may be too high, or reranker is being overly strict.
+    Raise `contradiction_threshold` to 0.7 or 0.8 and review whether the corpus is balanced (not just prohibitions).
+  </Accordion>
 
-    **Solution**:
-    - Raise `contradiction_threshold` to 0.7 or 0.8
-    - Review the chunk verdicts to understand what's being flagged
-    - Ensure regulatory corpus is balanced (not just prohibitions)
+  <Accordion title="Verdict and Compliance Score Disagree">
+    This should not happen with the current implementation — `verdict` is always derived from `compliance_score`. If you see a discrepancy, file a bug report.
   </Accordion>
 
   <Accordion title="Out of Memory Errors">
-    **Cause**: Large corpus or models don't fit in GPU memory.
-
-    **Solution**:
-    - Use smaller models (0.6B versions)
-    - Reduce `batch_size` to 16 or 8
-    - Process fewer documents at a time
-    - Use CPU fallback (slower but works)
-  </Accordion>
-
-  <Accordion title="Slow Processing">
-    **Cause**: Large corpus, many conversations, or no GPU.
-
-    **Solution**:
-    - Reduce corpus size by removing irrelevant documents
-    - Increase chunk size to reduce total chunks
-    - Ensure GPU is being used (check `device_map="auto"`)
-    - Use smaller models for faster inference
+    Use smaller models (0.6B), reduce `batch_size` to 16 or 8, or fall back to CPU.
   </Accordion>
 </AccordionGroup>
+
+## Use Cases
+
+<CardGroup cols={2}>
+  <Card title="Financial Compliance" icon="building-columns">
+    Verify responses comply with banking regulations, KYC requirements, and financial advice rules
+  </Card>
+  <Card title="Healthcare HIPAA" icon="hospital">
+    Ensure patient data handling follows HIPAA guidelines
+  </Card>
+  <Card title="Call Center Policies" icon="headset">
+    Check responses against company policies and consumer protection laws
+  </Card>
+  <Card title="Legal Compliance" icon="scale-balanced">
+    Validate AI-generated legal content against jurisdiction-specific regulations
+  </Card>
+</CardGroup>
 
 ## Next Steps
 
 <CardGroup cols={3}>
-  <Card title="Context Metric" icon="bullseye" href="/metrics/context">
-    Evaluate response alignment with provided context
+  <Card title="Statistical Modes" icon="chart-line" href="/core-concepts/statistical-modes">
+    Frequentist vs Bayesian — when each matters
   </Card>
-  <Card title="Storage Backends" icon="hard-drive" href="/storage/overview">
-    Configure LakeFS or local storage for your corpus
+  <Card title="Context Metric" icon="bullseye" href="/metrics/context">
+    Evaluate response alignment with system context
   </Card>
   <Card title="AWS Lambda" icon="aws" href="/examples/aws-lambda">
     Deploy Regulatory as a serverless function

--- a/fair_forge/core/base.py
+++ b/fair_forge/core/base.py
@@ -4,11 +4,14 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from fair_forge.utils.logging import VerboseLogger
 
 if TYPE_CHECKING:
     from fair_forge.core.retriever import Retriever
     from fair_forge.schemas.common import Batch
+    from fair_forge.statistical.base import StatisticalMode
 
 
 class FairForge(ABC):
@@ -127,6 +130,61 @@ class FairForge(ABC):
                 batch=[streamed.batch],
                 language=streamed.metadata.language,
             )
+
+    def _resolve_weights(self, batch: list["Batch"]) -> dict[str, float]:
+        n = len(batch)
+        if n == 0:
+            return {}
+
+        weighted = {b.qa_id: b.weight for b in batch if b.weight is not None}
+        unweighted_ids = [b.qa_id for b in batch if b.weight is None]
+
+        if not weighted:
+            return {b.qa_id: 1.0 / n for b in batch}
+
+        if not unweighted_ids:
+            total = sum(weighted.values())
+            if abs(total - 1.0) > 1e-6:
+                self.logger.warning(
+                    f"Provided weights sum to {total:.4f}, not 1.0. Falling back to equal weights."
+                )
+                return {b.qa_id: 1.0 / n for b in batch}
+            return weighted
+
+        assigned = sum(weighted.values())
+        remaining = max(0.0, 1.0 - assigned)
+        per_unweighted = remaining / len(unweighted_ids)
+        return {**weighted, **{qa_id: per_unweighted for qa_id in unweighted_ids}}
+
+    def _aggregate_scores(
+        self,
+        scores: list[float],
+        batches: list["Batch"],
+        weights: dict[str, float],
+        statistical_mode: "StatisticalMode",
+    ) -> tuple[float, float | None, float | None]:
+        if statistical_mode.get_result_type() == "point_estimate":
+            metrics_dict = {b.qa_id: score for b, score in zip(batches, scores, strict=False)}
+            result = statistical_mode.aggregate_metrics(metrics_dict, weights)
+            return float(result), None, None
+
+        mc_samples = getattr(statistical_mode, "mc_samples", 5000)
+        ci_level = getattr(statistical_mode, "ci_level", 0.95)
+        np_scores = np.array(scores)
+        np_weights = np.array([weights[b.qa_id] for b in batches])
+        np_weights = np_weights / np_weights.sum()
+
+        bootstrap_means = np.array([
+            float(np.mean(np_scores[np.random.choice(len(scores), size=len(scores), replace=True, p=np_weights)]))
+            for _ in range(mc_samples)
+        ])
+
+        alpha = (1.0 - ci_level) / 2.0
+        return (
+            float(np.mean(bootstrap_means)),
+            float(np.quantile(bootstrap_means, alpha)),
+            float(np.quantile(bootstrap_means, 1.0 - alpha)),
+        )
 
     def on_process_complete(self):  # noqa: B027
         """Optional hook evaluated after all dataset elements are processed. Useful for accumulator metrics."""

--- a/fair_forge/core/base.py
+++ b/fair_forge/core/base.py
@@ -186,12 +186,9 @@ class FairForge(ABC):
         else:
             np_weights = np_weights / total_weight
 
-        bootstrap_means = np.array(
-            [
-                float(np.mean(np_scores[rng.choice(len(scores), size=len(scores), replace=True, p=np_weights)]))
-                for _ in range(mc_samples)
-            ]
-        )
+        n_scores = len(scores)
+        bootstrap_indices = rng.choice(n_scores, size=(mc_samples, n_scores), replace=True, p=np_weights)
+        bootstrap_means = np_scores[bootstrap_indices].mean(axis=1)
 
         alpha = (1.0 - ci_level) / 2.0
         return (

--- a/fair_forge/core/base.py
+++ b/fair_forge/core/base.py
@@ -174,13 +174,21 @@ class FairForge(ABC):
 
         mc_samples = getattr(statistical_mode, "mc_samples", 5000)
         ci_level = getattr(statistical_mode, "ci_level", 0.95)
+        rng = getattr(statistical_mode, "rng", np.random.default_rng())
         np_scores = np.array(scores)
         np_weights = np.array([weights[b.qa_id] for b in batches])
-        np_weights = np_weights / np_weights.sum()
+        total_weight = np_weights.sum()
+        if total_weight <= 0.0:
+            self.logger.warning(
+                "Non-positive total weight encountered during aggregation. Falling back to equal weights."
+            )
+            np_weights = np.ones_like(np_weights, dtype=float) / len(np_weights)
+        else:
+            np_weights = np_weights / total_weight
 
         bootstrap_means = np.array(
             [
-                float(np.mean(np_scores[np.random.choice(len(scores), size=len(scores), replace=True, p=np_weights)]))
+                float(np.mean(np_scores[rng.choice(len(scores), size=len(scores), replace=True, p=np_weights)]))
                 for _ in range(mc_samples)
             ]
         )

--- a/fair_forge/core/base.py
+++ b/fair_forge/core/base.py
@@ -145,14 +145,18 @@ class FairForge(ABC):
         if not unweighted_ids:
             total = sum(weighted.values())
             if abs(total - 1.0) > 1e-6:
-                self.logger.warning(
-                    f"Provided weights sum to {total:.4f}, not 1.0. Falling back to equal weights."
-                )
+                self.logger.warning(f"Provided weights sum to {total:.4f}, not 1.0. Falling back to equal weights.")
                 return {b.qa_id: 1.0 / n for b in batch}
             return weighted
 
         assigned = sum(weighted.values())
-        remaining = max(0.0, 1.0 - assigned)
+        if assigned >= 1.0:
+            self.logger.warning(
+                f"Provided weights sum to {assigned:.4f} >= 1.0 with {len(unweighted_ids)} unweighted "
+                "interaction(s). Falling back to equal weights."
+            )
+            return {b.qa_id: 1.0 / n for b in batch}
+        remaining = 1.0 - assigned
         per_unweighted = remaining / len(unweighted_ids)
         return {**weighted, **{qa_id: per_unweighted for qa_id in unweighted_ids}}
 
@@ -174,10 +178,12 @@ class FairForge(ABC):
         np_weights = np.array([weights[b.qa_id] for b in batches])
         np_weights = np_weights / np_weights.sum()
 
-        bootstrap_means = np.array([
-            float(np.mean(np_scores[np.random.choice(len(scores), size=len(scores), replace=True, p=np_weights)]))
-            for _ in range(mc_samples)
-        ])
+        bootstrap_means = np.array(
+            [
+                float(np.mean(np_scores[np.random.choice(len(scores), size=len(scores), replace=True, p=np_weights)]))
+                for _ in range(mc_samples)
+            ]
+        )
 
         alpha = (1.0 - ci_level) / 2.0
         return (

--- a/fair_forge/metrics/agentic.py
+++ b/fair_forge/metrics/agentic.py
@@ -6,10 +6,13 @@ from typing import Any
 from langchain_core.language_models.chat_models import BaseChatModel
 from pydantic import BaseModel, Field
 
+import numpy as np
+
 from fair_forge.core import FairForge, Retriever
 from fair_forge.llm import Judge
 from fair_forge.schemas import Batch
 from fair_forge.schemas.agentic import AgenticMetric, ToolCorrectnessScore
+from fair_forge.statistical import FrequentistMode, StatisticalMode
 
 
 class AnswerCorrectnessOutput(BaseModel):
@@ -120,6 +123,7 @@ class Agentic(FairForge):
         threshold: float = 0.7,
         tool_threshold: float = 1.0,
         tool_weights: dict[str, float] | None = None,
+        statistical_mode: StatisticalMode | None = None,
         **kwargs,
     ):
         super().__init__(retriever, **kwargs)
@@ -140,9 +144,11 @@ class Agentic(FairForge):
                 "utilization": 0.25,
             }
         self.tool_weights = tool_weights
+        self.statistical_mode = statistical_mode if statistical_mode is not None else FrequentistMode()
 
         self.logger.info(f"Initialized Agentic metric with model: {model.__class__.__name__}")
         self.logger.info(f"Thresholds - Answer: {threshold}, Tool: {tool_threshold}")
+        self.logger.info(f"Statistical mode: {self.statistical_mode.get_result_type()}")
 
     @classmethod
     def run(cls, retriever: type[Retriever], k: int, **kwargs) -> list[AgenticMetric]:
@@ -424,20 +430,48 @@ Examples:
             status = "✅ FULLY CORRECT" if is_fully_correct else f"❌ PARTIAL ({correct_interactions}/{total_interactions})"
             self.logger.info(f"  Conversation result: {status}")
 
-            metric = AgenticMetric(
-                session_id=dataset.session_id,
-                assistant_id=dataset.assistant_id,
-                total_interactions=total_interactions,
-                correct_interactions=correct_interactions,
-                is_fully_correct=is_fully_correct,
-                threshold=self.threshold,
-                correctness_scores=correctness_scores,
-                correct_indices=correct_indices,
-                tool_correctness_scores=tool_correctness_scores if tool_correctness_scores else [],
-                k=self.k,
-                pass_at_k=pass_at_k(total_interactions, correct_interactions, self.k),
-                pass_pow_k=pass_pow_k(total_interactions, correct_interactions, self.k),
-            )
+            p_result = self.statistical_mode.rate_estimation(correct_interactions, total_interactions)
+
+            if self.statistical_mode.get_result_type() == "point_estimate":
+                p = float(p_result)
+                metric = AgenticMetric(
+                    session_id=dataset.session_id,
+                    assistant_id=dataset.assistant_id,
+                    total_interactions=total_interactions,
+                    correct_interactions=correct_interactions,
+                    is_fully_correct=is_fully_correct,
+                    threshold=self.threshold,
+                    correctness_scores=correctness_scores,
+                    correct_indices=correct_indices,
+                    tool_correctness_scores=tool_correctness_scores if tool_correctness_scores else [],
+                    k=self.k,
+                    pass_at_k=pass_at_k(total_interactions, correct_interactions, self.k),
+                    pass_pow_k=pass_pow_k(total_interactions, correct_interactions, self.k),
+                )
+            else:
+                p_samples = p_result["samples"]
+                pass_at_k_samples = 1.0 - (1.0 - p_samples) ** self.k
+                pass_pow_k_samples = p_samples**self.k
+
+                alpha = (1.0 - getattr(self.statistical_mode, "ci_level", 0.95)) / 2.0
+                metric = AgenticMetric(
+                    session_id=dataset.session_id,
+                    assistant_id=dataset.assistant_id,
+                    total_interactions=total_interactions,
+                    correct_interactions=correct_interactions,
+                    is_fully_correct=is_fully_correct,
+                    threshold=self.threshold,
+                    correctness_scores=correctness_scores,
+                    correct_indices=correct_indices,
+                    tool_correctness_scores=tool_correctness_scores if tool_correctness_scores else [],
+                    k=self.k,
+                    pass_at_k=float(np.mean(pass_at_k_samples)),
+                    pass_at_k_ci_low=float(np.quantile(pass_at_k_samples, alpha)),
+                    pass_at_k_ci_high=float(np.quantile(pass_at_k_samples, 1.0 - alpha)),
+                    pass_pow_k=float(np.mean(pass_pow_k_samples)),
+                    pass_pow_k_ci_low=float(np.quantile(pass_pow_k_samples, alpha)),
+                    pass_pow_k_ci_high=float(np.quantile(pass_pow_k_samples, 1.0 - alpha)),
+                )
 
             self.metrics.append(metric)
 

--- a/fair_forge/metrics/bias.py
+++ b/fair_forge/metrics/bias.py
@@ -1,10 +1,9 @@
-import scipy.stats as st
-from pydantic import BaseModel
 from tqdm import tqdm
 
 from fair_forge.core import FairForge, Guardian, Retriever
 from fair_forge.schemas import Batch
 from fair_forge.schemas.bias import BiasMetric, ProtectedAttribute
+from fair_forge.statistical import FrequentistMode, StatisticalMode
 
 
 class Bias(FairForge):
@@ -12,51 +11,23 @@ class Bias(FairForge):
     A class for measuring and analyzing bias in AI assistant responses.
 
     This class implements various methods to detect and quantify bias across different protected attributes
-    such as gender, race, religion, nationality, and sexual orientation. It uses a combination of
-    confidence intervals and guardian-based bias detection to provide comprehensive bias analysis.
+    such as gender, race, religion, nationality, and sexual orientation. It uses a guardian-based
+    bias detection to provide comprehensive bias analysis, with pluggable statistical computation
+    via StatisticalMode (frequentist or Bayesian).
 
     Attributes:
         protected_attributes (list[ProtectedAttribute]): List of protected attributes to monitor for bias
         guardian (Guardian): Instance of the Guardian class for bias detection
-        confidence_level (float): Confidence level for statistical calculations (default: 0.95)
+        statistical_mode (StatisticalMode): Statistical computation mode
     """
-
-    class ClopperPearson(BaseModel):
-        """
-        A model representing Clopper-Pearson confidence interval parameters.
-
-        Attributes:
-            lower_bound (float): Lower bound of the confidence interval
-            upper_bound (float): Upper bound of the confidence interval
-            probability (float): True probability of success
-            samples (int): Total number of samples
-            k_success (int): Number of successful outcomes
-            alpha (float): Significance level
-        """
-
-        lower_bound: float
-        upper_bound: float
-        probability: float
-        samples: int
-        k_success: int
-        alpha: float
 
     def __init__(
         self,
         retriever: type[Retriever],
         guardian: type[Guardian],
-        confidence_level: float = 0.95,
+        statistical_mode: StatisticalMode | None = None,
         **kwargs,
     ):
-        """
-        Initialize the Bias class with configuration parameters.
-
-        Args:
-            retriever (Type[Retriever]): The retriever class to use
-            guardian (Type[Guardian]): The guardian class for bias detection
-            confidence_level (float, optional): Confidence level for statistical calculations. Defaults to 0.95.
-            **kwargs: Additional keyword arguments passed to the parent class
-        """
         super().__init__(retriever, **kwargs)
         self.protected_attributes = [
             ProtectedAttribute(
@@ -82,54 +53,17 @@ class Bias(FairForge):
         ]  # PROTECTED ATTRIBUTES DEFINED BY FAIR FORGE
 
         self.guardian = guardian(**kwargs)
-        self.confidence_level = confidence_level
+        self.statistical_mode = statistical_mode if statistical_mode is not None else FrequentistMode()
 
         self.logger.info("--BIAS CONFIGURATION--")
-        self.logger.debug(f"Confidence level: {self.confidence_level}")
+        self.logger.debug(f"Statistical mode: {self.statistical_mode.get_result_type()}")
 
-        # List protected attributes
         for attribute in self.protected_attributes:
             self.logger.debug(f"Protected attribute: {attribute.attribute.value}")
-
-    def _clopper_pearson_confidence_interval(self, samples: int, k_success: int) -> ClopperPearson:
-        """
-        Calculate the Clopper-Pearson confidence interval for a binomial proportion.
-
-        Args:
-            samples (int): Total number of samples
-            k_success (int): Number of successful outcomes
-
-        Returns:
-            ClopperPearson: Object containing confidence interval parameters
-        """
-        alpha = 1 - self.confidence_level
-        if k_success == samples:
-            p_truth = 1.0
-            p_u = 1.0
-        else:
-            p_truth = k_success / samples
-            p_u = st.beta.ppf(1 - alpha / 2, k_success + 1, samples - k_success)
-
-        p_l = st.beta.ppf(alpha / 2, k_success, samples - k_success + 1)
-
-        return self.ClopperPearson(
-            lower_bound=p_l, upper_bound=p_u, probability=p_truth, samples=samples, k_success=k_success, alpha=alpha
-        )
 
     def _get_guardian_biased_attributes(
         self, batch: list[Batch], attributes: list[ProtectedAttribute], context: str
     ) -> dict[str, list[BiasMetric.GuardianInteraction]]:
-        """
-        Analyze batch interactions for bias using the guardian model.
-
-        Args:
-            batch (list[Batch]): List of batch interactions to analyze
-            attributes (list[ProtectedAttribute]): List of protected attributes to check
-            context (str): Context information for bias analysis
-
-        Returns:
-            dict[str,list[BiasMetric.GuardianInteraction]]: Dictionary mapping attributes to their bias analysis results
-        """
         biases_by_attribute = {attribute.attribute.value: [] for attribute in self.protected_attributes}
         for interaction in tqdm(
             batch,
@@ -153,36 +87,37 @@ class Bias(FairForge):
                 )
         return biases_by_attribute
 
-    def _calculate_confidence_intervals(
+    def _calculate_attribute_rates(
         self, biases_by_attributes: dict[str, list[BiasMetric.GuardianInteraction]]
-    ) -> list[BiasMetric.ConfidenceInterval]:
-        """
-        Calculate confidence intervals for bias measurements across all protected attributes.
-
-        Args:
-            biases_by_attributes (dict[str, list[BiasMetric.GuardianInteraction]]): Dictionary of bias analysis results
-
-        Returns:
-            list[BiasMetric.ConfidenceInterval]: List of confidence intervals for each protected attribute
-        """
-        intervals = []
+    ) -> list[BiasMetric.AttributeBiasRate]:
+        rates = []
         for attribute in self.protected_attributes:
-            samples = len(biases_by_attributes[attribute.attribute.value])
-            k_success = sum(1 for bias in biases_by_attributes[attribute.attribute.value] if not bias.is_biased)
-            clopper_pearson = self._clopper_pearson_confidence_interval(samples, k_success)
-            confidence_interval = BiasMetric.ConfidenceInterval(
-                alpha=clopper_pearson.alpha,
-                lower_bound=clopper_pearson.lower_bound,
-                upper_bound=clopper_pearson.upper_bound,
-                probability=clopper_pearson.probability,
-                samples=clopper_pearson.samples,
-                k_success=clopper_pearson.k_success,
-                confidence_level=self.confidence_level,
-                protected_attribute=attribute.attribute.value,
-            )
-            intervals.append(confidence_interval)
+            interactions = biases_by_attributes[attribute.attribute.value]
+            n_samples = len(interactions)
+            k_biased = sum(1 for bias in interactions if bias.is_biased)
 
-        return intervals
+            result = self.statistical_mode.rate_estimation(k_biased, n_samples)
+
+            if self.statistical_mode.get_result_type() == "point_estimate":
+                rate = BiasMetric.AttributeBiasRate(
+                    protected_attribute=attribute.attribute.value,
+                    n_samples=n_samples,
+                    k_biased=k_biased,
+                    rate=float(result),
+                )
+            else:
+                rate = BiasMetric.AttributeBiasRate(
+                    protected_attribute=attribute.attribute.value,
+                    n_samples=n_samples,
+                    k_biased=k_biased,
+                    rate=float(result["mean"]),
+                    ci_low=float(result["ci_low"]),
+                    ci_high=float(result["ci_high"]),
+                )
+
+            rates.append(rate)
+
+        return rates
 
     def batch(
         self,
@@ -192,28 +127,16 @@ class Bias(FairForge):
         batch: list[Batch],
         language: str = "en",
     ):
-        """
-        Process a batch of interactions to analyze bias.
-
-        This method serves as the main interface for bias analysis, using guardian-based
-        bias detection and confidence interval calculations.
-
-        Args:
-            session_id (str): Unique identifier for the analysis session
-            context (str): Context information for bias analysis
-            assistant_id (str): Identifier for the AI assistant being analyzed
-            batch (list[Batch]): List of batch interactions to analyze
-        """
         biases_by_attribute = self._get_guardian_biased_attributes(batch, self.protected_attributes, context)
 
         self.logger.info(f"Biases by attribute: {biases_by_attribute}")
 
-        confidence_intervals = self._calculate_confidence_intervals(biases_by_attribute)
+        attribute_rates = self._calculate_attribute_rates(biases_by_attribute)
 
         bias_metric = BiasMetric(
             session_id=session_id,
             assistant_id=assistant_id,
-            confidence_intervals=confidence_intervals,
+            attribute_rates=attribute_rates,
             guardian_interactions=biases_by_attribute,
         )
         self.metrics.append(bias_metric)

--- a/fair_forge/metrics/context.py
+++ b/fair_forge/metrics/context.py
@@ -9,15 +9,22 @@ from fair_forge.llm.prompts import (
     context_reasoning_system_prompt_observation,
 )
 from fair_forge.schemas import Batch
-from fair_forge.schemas.context import ContextMetric
+from fair_forge.schemas.context import ContextInteraction, ContextMetric
+from fair_forge.statistical import FrequentistMode, StatisticalMode
 
 
 class Context(FairForge):
     """Metric for evaluating how well AI responses align with provided context.
 
+    Accumulates per-interaction context_awareness scores across the session and
+    emits one session-level ContextMetric in on_process_complete(). The score is
+    aggregated using the configured StatisticalMode — frequentist returns a
+    weighted mean, Bayesian returns a bootstrapped credible interval.
+
     Args:
         retriever: Retriever class for loading datasets
         model: LangChain BaseChatModel instance for evaluation
+        statistical_mode: Statistical computation mode (defaults to FrequentistMode)
         use_structured_output: If True, use LangChain's with_structured_output()
         bos_json_clause: Opening marker for JSON blocks
         eos_json_clause: Closing marker for JSON blocks
@@ -28,6 +35,7 @@ class Context(FairForge):
         self,
         retriever: type[Retriever],
         model: BaseChatModel,
+        statistical_mode: StatisticalMode | None = None,
         use_structured_output: bool = False,
         bos_json_clause: str = "```json",
         eos_json_clause: str = "```",
@@ -35,9 +43,11 @@ class Context(FairForge):
     ):
         super().__init__(retriever, **kwargs)
         self.model = model
+        self.statistical_mode = statistical_mode if statistical_mode is not None else FrequentistMode()
         self.use_structured_output = use_structured_output
         self.bos_json_clause = bos_json_clause
         self.eos_json_clause = eos_json_clause
+        self._session_data: dict[str, dict] = {}
 
     def batch(
         self,
@@ -54,49 +64,63 @@ class Context(FairForge):
             eos_json_clause=self.eos_json_clause,
             verbose=self.verbose,
         )
+
+        if session_id not in self._session_data:
+            self._session_data[session_id] = {
+                "assistant_id": assistant_id,
+                "batches": [],
+                "scores": [],
+                "interactions": [],
+            }
+
         for interaction in batch:
             self.logger.debug(f"QA ID: {interaction.qa_id}")
 
-            query = interaction.query
-            data = {
-                "context": context,
-                "assistant_answer": interaction.assistant,
-            }
+            data = {"context": context, "assistant_answer": interaction.assistant}
+
             if interaction.observation:
                 reasoning, result = judge.check(
                     context_reasoning_system_prompt_observation,
-                    query,
+                    interaction.query,
                     {"observation": interaction.observation, **data},
                     output_schema=ContextJudgeOutput,
                 )
             else:
                 reasoning, result = judge.check(
                     context_reasoning_system_prompt,
-                    query,
+                    interaction.query,
                     {"ground_truth_assistant": interaction.assistant, **data},
                     output_schema=ContextJudgeOutput,
                 )
 
             if result is None:
-                raise ValueError(f"[FAIR FORGE/CONTEXT] No valid response from judge for QA ID: {interaction.qa_id}")
+                raise ValueError(
+                    f"[FAIR FORGE/CONTEXT] No valid response from judge for QA ID: {interaction.qa_id}"
+                )
 
-            # Handle both Pydantic model and dict results
-            if isinstance(result, dict):
-                insight = result["insight"]
-                score = result["score"]
-            else:
-                insight = result.insight
-                score = result.score
+            score = float(result["score"] if isinstance(result, dict) else result.score)
+            self._session_data[session_id]["batches"].append(interaction)
+            self._session_data[session_id]["scores"].append(score)
+            self._session_data[session_id]["interactions"].append(
+                ContextInteraction(qa_id=interaction.qa_id, context_awareness=score)
+            )
+
+    def on_process_complete(self):
+        for session_id, data in self._session_data.items():
+            batches = data["batches"]
+            weights = self._resolve_weights(batches)
+
+            mean, ci_low, ci_high = self._aggregate_scores(
+                data["scores"], batches, weights, self.statistical_mode
+            )
 
             metric = ContextMetric(
-                context_insight=insight,
-                context_thinkings=reasoning,
-                context_awareness=score,
                 session_id=session_id,
-                assistant_id=assistant_id,
-                qa_id=interaction.qa_id,
+                assistant_id=data["assistant_id"],
+                n_interactions=len(batches),
+                context_awareness=mean,
+                context_awareness_ci_low=ci_low,
+                context_awareness_ci_high=ci_high,
+                interactions=data["interactions"],
             )
-            self.logger.debug(f"Context insight: {metric.context_insight}")
-            self.logger.debug(f"Context awareness: {metric.context_awareness}")
-            self.logger.debug(f"Context thinkings: {metric.context_thinkings}")
             self.metrics.append(metric)

--- a/fair_forge/metrics/conversational.py
+++ b/fair_forge/metrics/conversational.py
@@ -9,28 +9,36 @@ from fair_forge.llm.prompts import (
     conversational_reasoning_system_prompt_observation,
 )
 from fair_forge.schemas import Batch
-from fair_forge.schemas.conversational import ConversationalMetric
+from fair_forge.schemas.conversational import ConversationalInteraction, ConversationalMetric, ConversationalScore
+from fair_forge.statistical import FrequentistMode, StatisticalMode
 
 
 class Conversational(FairForge):
     """Metric for evaluating conversational quality using Grice's maxims.
 
-    Evaluates memory recall, language appropriateness, and Grice's maxims:
-    quality, quantity, relation, manner, and sensibleness.
+    Accumulates per-interaction judge scores across the session and emits one
+    session-level ConversationalMetric in on_process_complete(). Each dimension
+    (memory, language, quality_maxim, etc.) is aggregated using the configured
+    StatisticalMode — frequentist returns a weighted mean, Bayesian returns a
+    bootstrapped credible interval.
 
     Args:
         retriever: Retriever class for loading datasets
         model: LangChain BaseChatModel instance for evaluation
+        statistical_mode: Statistical computation mode (defaults to FrequentistMode)
         use_structured_output: If True, use LangChain's with_structured_output()
         bos_json_clause: Opening marker for JSON blocks
         eos_json_clause: Closing marker for JSON blocks
         **kwargs: Additional arguments passed to FairForge base class
     """
 
+    _DIMENSIONS = ("memory", "language", "quality_maxim", "quantity_maxim", "relation_maxim", "manner_maxim", "sensibleness")
+
     def __init__(
         self,
         retriever: type[Retriever],
         model: BaseChatModel,
+        statistical_mode: StatisticalMode | None = None,
         use_structured_output: bool = False,
         bos_json_clause: str = "```json",
         eos_json_clause: str = "```",
@@ -38,9 +46,16 @@ class Conversational(FairForge):
     ):
         super().__init__(retriever, **kwargs)
         self.model = model
+        self.statistical_mode = statistical_mode if statistical_mode is not None else FrequentistMode()
         self.use_structured_output = use_structured_output
         self.bos_json_clause = bos_json_clause
         self.eos_json_clause = eos_json_clause
+        self._session_data: dict[str, dict] = {}
+
+    def _extract_scores(self, result) -> dict[str, float]:
+        if isinstance(result, dict):
+            return {dim: float(result[dim]) for dim in self._DIMENSIONS}
+        return {dim: float(getattr(result, dim)) for dim in self._DIMENSIONS}
 
     def batch(
         self,
@@ -56,13 +71,20 @@ class Conversational(FairForge):
             bos_json_clause=self.bos_json_clause,
             eos_json_clause=self.eos_json_clause,
         )
+
+        if session_id not in self._session_data:
+            self._session_data[session_id] = {
+                "assistant_id": assistant_id,
+                "batches": [],
+                "dimension_scores": {dim: [] for dim in self._DIMENSIONS},
+                "interactions": [],
+            }
+
         for interaction in batch:
             self.logger.debug(f"QA ID: {interaction.qa_id}")
 
-            data = {
-                "preferred_language": language,
-                "assistant_answer": interaction.assistant,
-            }
+            data = {"preferred_language": language, "assistant_answer": interaction.assistant}
+
             if interaction.observation:
                 reasoning, result = judge.check(
                     conversational_reasoning_system_prompt_observation,
@@ -83,42 +105,37 @@ class Conversational(FairForge):
                     f"[FAIR FORGE/CONVERSATIONAL] No valid response from judge for QA ID: {interaction.qa_id}"
                 )
 
-            if self.use_structured_output:
-                metric = ConversationalMetric(
-                    session_id=session_id,
-                    qa_id=interaction.qa_id,
-                    assistant_id=assistant_id,
-                    conversational_insight=result.insight,
-                    conversational_memory=result.memory,
-                    conversational_language=result.language,
-                    conversational_quality_maxim=result.quality_maxim,
-                    conversational_quantity_maxim=result.quantity_maxim,
-                    conversational_relation_maxim=result.relation_maxim,
-                    conversational_manner_maxim=result.manner_maxim,
-                    conversational_sensibleness=result.sensibleness,
-                    conversational_thinkings=reasoning,
-                )
-            else:
-                metric = ConversationalMetric(
-                    session_id=session_id,
-                    qa_id=interaction.qa_id,
-                    assistant_id=assistant_id,
-                    conversational_insight=result["insight"],
-                    conversational_memory=result["memory"],
-                    conversational_language=result["language"],
-                    conversational_quality_maxim=result["quality_maxim"],
-                    conversational_quantity_maxim=result["quantity_maxim"],
-                    conversational_relation_maxim=result["relation_maxim"],
-                    conversational_manner_maxim=result["manner_maxim"],
-                    conversational_sensibleness=result["sensibleness"],
-                    conversational_thinkings=reasoning,
-                )
+            scores = self._extract_scores(result)
+            self._session_data[session_id]["batches"].append(interaction)
+            for dim, score in scores.items():
+                self._session_data[session_id]["dimension_scores"][dim].append(score)
+            self._session_data[session_id]["interactions"].append(
+                ConversationalInteraction(qa_id=interaction.qa_id, **scores)
+            )
 
-            self.logger.debug(f"Conversational memory: {metric.conversational_memory}")
-            self.logger.debug(f"Conversational language: {metric.conversational_language}")
-            self.logger.debug(f"Conversational quality maxim: {metric.conversational_quality_maxim}")
-            self.logger.debug(f"Conversational quantity maxim: {metric.conversational_quantity_maxim}")
-            self.logger.debug(f"Conversational relation maxim: {metric.conversational_relation_maxim}")
-            self.logger.debug(f"Conversational manner maxim: {metric.conversational_manner_maxim}")
-            self.logger.debug(f"Conversational sensibleness: {metric.conversational_sensibleness}")
+    def on_process_complete(self):
+        for session_id, data in self._session_data.items():
+            batches = data["batches"]
+            weights = self._resolve_weights(batches)
+
+            dimension_metrics = {}
+            for dim in self._DIMENSIONS:
+                mean, ci_low, ci_high = self._aggregate_scores(
+                    data["dimension_scores"][dim], batches, weights, self.statistical_mode
+                )
+                dimension_metrics[dim] = ConversationalScore(mean=mean, ci_low=ci_low, ci_high=ci_high)
+
+            metric = ConversationalMetric(
+                session_id=session_id,
+                assistant_id=data["assistant_id"],
+                n_interactions=len(batches),
+                conversational_memory=dimension_metrics["memory"],
+                conversational_language=dimension_metrics["language"],
+                conversational_quality_maxim=dimension_metrics["quality_maxim"],
+                conversational_quantity_maxim=dimension_metrics["quantity_maxim"],
+                conversational_relation_maxim=dimension_metrics["relation_maxim"],
+                conversational_manner_maxim=dimension_metrics["manner_maxim"],
+                conversational_sensibleness=dimension_metrics["sensibleness"],
+                interactions=data["interactions"],
+            )
             self.metrics.append(metric)

--- a/fair_forge/metrics/regulatory.py
+++ b/fair_forge/metrics/regulatory.py
@@ -9,20 +9,23 @@ from fair_forge.core import FairForge, Retriever
 from fair_forge.core.embedder import ChunkerConfig, EmbedderConfig, RegulatoryEmbedder
 from fair_forge.core.reranker import RegulatoryReranker, RerankerConfig
 from fair_forge.schemas import Batch  # noqa: TC001
-from fair_forge.schemas.regulatory import RegulatoryChunk, RegulatoryMetric
+from fair_forge.schemas.regulatory import RegulatoryChunk, RegulatoryInteraction, RegulatoryMetric
+from fair_forge.statistical import FrequentistMode, StatisticalMode
 
 
 class Regulatory(FairForge):
     """
     Evaluates AI assistant responses against a regulatory corpus.
 
-    Uses embedding-based retrieval to find relevant regulatory chunks,
-    then applies a reranker to detect contradictions between the response
-    and applicable regulations.
+    Accumulates per-interaction compliance scores and emits one session-level
+    RegulatoryMetric in on_process_complete(). The aggregated compliance score
+    uses the configured StatisticalMode — frequentist returns a weighted mean,
+    Bayesian returns a bootstrapped credible interval.
 
     Args:
         retriever: Retriever class for loading conversation datasets.
         corpus_connector: Connector for loading regulatory documents.
+        statistical_mode: Statistical computation mode (defaults to FrequentistMode).
         embedding_model: Name of the embedding model to use.
         reranker_model: Name of the reranker model to use.
         chunk_size: Character size for text chunks.
@@ -40,6 +43,7 @@ class Regulatory(FairForge):
         self,
         retriever: type[Retriever],
         corpus_connector: CorpusConnector,
+        statistical_mode: StatisticalMode | None = None,
         embedding_model: str = "Qwen/Qwen3-Embedding-0.6B",
         reranker_model: str = "Qwen/Qwen3-Reranker-0.6B",
         chunk_size: int = 1000,
@@ -55,6 +59,8 @@ class Regulatory(FairForge):
         super().__init__(retriever, **kwargs)
 
         self.corpus_connector = corpus_connector
+        self.statistical_mode = statistical_mode if statistical_mode is not None else FrequentistMode()
+        self.compliance_threshold = compliance_threshold
 
         embedder_config = EmbedderConfig(
             model_name=embedding_model,
@@ -77,7 +83,7 @@ class Regulatory(FairForge):
         self.reranker = RegulatoryReranker(reranker_config)
 
         self._corpus_loaded = False
-        self.compliance_threshold = compliance_threshold
+        self._session_data: dict[str, dict] = {}
 
         self.logger.info("--REGULATORY CONFIGURATION--")
         self.logger.info(f"Embedding model: {embedding_model}")
@@ -86,12 +92,11 @@ class Regulatory(FairForge):
         self.logger.info(f"Top-K: {top_k}, Similarity threshold: {similarity_threshold}")
         self.logger.info(f"Contradiction threshold: {contradiction_threshold}")
         self.logger.info(f"Compliance threshold: {compliance_threshold}")
+        self.logger.info(f"Statistical mode: {self.statistical_mode.get_result_type()}")
 
     def _ensure_corpus_loaded(self) -> None:
-        """Load and index the regulatory corpus if not already done."""
         if self._corpus_loaded:
             return
-
         documents = self.corpus_connector.load_documents()
         num_chunks = self.embedder.load_corpus(documents)
         self.logger.info(f"Loaded corpus: {len(documents)} documents -> {num_chunks} chunks")
@@ -102,12 +107,6 @@ class Regulatory(FairForge):
         supporting: int,
         contradicting: int,
     ) -> tuple[Literal["COMPLIANT", "NON_COMPLIANT", "IRRELEVANT"], float]:
-        """
-        Compute overall verdict and compliance score.
-
-        Returns:
-            Tuple of (verdict, compliance_score).
-        """
         total = supporting + contradicting
 
         if total == 0:
@@ -123,13 +122,7 @@ class Regulatory(FairForge):
 
         return "NON_COMPLIANT", compliance_score
 
-    def _generate_insight(
-        self,
-        verdict: str,
-        supporting: int,
-        contradicting: int,
-    ) -> str:
-        """Generate human-readable insight about the compliance evaluation."""
+    def _generate_insight(self, verdict: str, supporting: int, contradicting: int) -> str:
         total = supporting + contradicting
 
         if verdict == "IRRELEVANT":
@@ -148,17 +141,15 @@ class Regulatory(FairForge):
         batch: list[Batch],
         language: str | None = "english",
     ):
-        """
-        Process a batch of conversations for regulatory compliance.
-
-        Args:
-            session_id: Unique session identifier.
-            context: Context information for the conversation.
-            assistant_id: ID of the assistant being evaluated.
-            batch: List of Q&A interactions to evaluate.
-            language: Language of the conversation.
-        """
         self._ensure_corpus_loaded()
+
+        if session_id not in self._session_data:
+            self._session_data[session_id] = {
+                "assistant_id": assistant_id,
+                "batches": [],
+                "scores": [],
+                "interactions": [],
+            }
 
         for interaction in batch:
             self.logger.debug(f"QA ID: {interaction.qa_id}")
@@ -169,9 +160,7 @@ class Regulatory(FairForge):
             )
 
             if not retrieved:
-                metric = RegulatoryMetric(
-                    session_id=session_id,
-                    assistant_id=assistant_id,
+                interaction_result = RegulatoryInteraction(
                     qa_id=interaction.qa_id,
                     query=interaction.query,
                     assistant=interaction.assistant,
@@ -182,46 +171,75 @@ class Regulatory(FairForge):
                     retrieved_chunks=[],
                     insight="No relevant regulatory chunks were retrieved for this interaction.",
                 )
-                self.metrics.append(metric)
-                continue
+            else:
+                ranked = self.reranker.check_contradictions(
+                    agent_response=interaction.assistant,
+                    retrieved_chunks=retrieved,
+                )
 
-            ranked = self.reranker.check_contradictions(
-                agent_response=interaction.assistant,
-                retrieved_chunks=retrieved,
+                supporting = sum(1 for r in ranked if r.verdict == "SUPPORTS")
+                contradicting = sum(1 for r in ranked if r.verdict == "CONTRADICTS")
+                verdict, compliance_score = self._compute_verdict(supporting, contradicting)
+                insight = self._generate_insight(verdict, supporting, contradicting)
+
+                interaction_result = RegulatoryInteraction(
+                    qa_id=interaction.qa_id,
+                    query=interaction.query,
+                    assistant=interaction.assistant,
+                    compliance_score=round(compliance_score, 4),
+                    verdict=verdict,
+                    supporting_chunks=supporting,
+                    contradicting_chunks=contradicting,
+                    retrieved_chunks=[
+                        RegulatoryChunk(
+                            text=r.text,
+                            source=r.source,
+                            chunk_index=r.chunk_index,
+                            similarity=r.similarity,
+                            reranker_score=r.reranker_score,
+                            verdict=r.verdict,
+                        )
+                        for r in ranked
+                    ],
+                    insight=insight,
+                )
+
+            self._session_data[session_id]["batches"].append(interaction)
+            self._session_data[session_id]["scores"].append(interaction_result.compliance_score)
+            self._session_data[session_id]["interactions"].append(interaction_result)
+
+    def on_process_complete(self):
+        for session_id, data in self._session_data.items():
+            batches = data["batches"]
+            interactions = data["interactions"]
+            weights = self._resolve_weights(batches)
+
+            mean, ci_low, ci_high = self._aggregate_scores(
+                data["scores"], batches, weights, self.statistical_mode
             )
 
-            supporting = sum(1 for r in ranked if r.verdict == "SUPPORTS")
-            contradicting = sum(1 for r in ranked if r.verdict == "CONTRADICTS")
+            total_supporting = sum(i.supporting_chunks for i in interactions)
+            total_contradicting = sum(i.contradicting_chunks for i in interactions)
 
-            verdict, compliance_score = self._compute_verdict(supporting, contradicting)
-            insight = self._generate_insight(verdict, supporting, contradicting)
-
-            regulatory_chunks = [
-                RegulatoryChunk(
-                    text=r.text,
-                    source=r.source,
-                    chunk_index=r.chunk_index,
-                    similarity=r.similarity,
-                    reranker_score=r.reranker_score,
-                    verdict=r.verdict,
-                )
-                for r in ranked
-            ]
+            if all(i.verdict == "IRRELEVANT" for i in interactions):
+                session_verdict = "IRRELEVANT"
+            elif mean >= self.compliance_threshold:
+                session_verdict = "COMPLIANT"
+            else:
+                session_verdict = "NON_COMPLIANT"
 
             metric = RegulatoryMetric(
                 session_id=session_id,
-                assistant_id=assistant_id,
-                qa_id=interaction.qa_id,
-                query=interaction.query,
-                assistant=interaction.assistant,
-                compliance_score=round(compliance_score, 4),
-                verdict=verdict,
-                supporting_chunks=supporting,
-                contradicting_chunks=contradicting,
-                retrieved_chunks=regulatory_chunks,
-                insight=insight,
+                assistant_id=data["assistant_id"],
+                n_interactions=len(batches),
+                compliance_score=round(mean, 4),
+                compliance_score_ci_low=round(ci_low, 4) if ci_low is not None else None,
+                compliance_score_ci_high=round(ci_high, 4) if ci_high is not None else None,
+                verdict=session_verdict,
+                total_supporting_chunks=total_supporting,
+                total_contradicting_chunks=total_contradicting,
+                interactions=interactions,
             )
-
             self.metrics.append(metric)
 
 

--- a/fair_forge/schemas/agentic.py
+++ b/fair_forge/schemas/agentic.py
@@ -46,4 +46,8 @@ class AgenticMetric(BaseMetric):
     tool_correctness_scores: list[ToolCorrectnessScore | None] = []  # Tool scores per interaction
     k: int = 0
     pass_at_k: float = 0.0
+    pass_at_k_ci_low: float | None = None
+    pass_at_k_ci_high: float | None = None
     pass_pow_k: float = 0.0
+    pass_pow_k_ci_low: float | None = None
+    pass_pow_k_ci_high: float | None = None

--- a/fair_forge/schemas/bias.py
+++ b/fair_forge/schemas/bias.py
@@ -47,20 +47,18 @@ class BiasMetric(BaseMetric):
     Bias metric for evaluating the bias of the assistant's responses.
     """
 
-    class ConfidenceInterval(BaseModel):
-        lower_bound: float
-        upper_bound: float
-        probability: float
-        samples: int
-        k_success: int
-        alpha: float
-        confidence_level: float
+    class AttributeBiasRate(BaseModel):
         protected_attribute: str
+        n_samples: int
+        k_biased: int
+        rate: float
+        ci_low: float | None = None
+        ci_high: float | None = None
 
     class GuardianInteraction(GuardianBias):
         qa_id: str
 
-    confidence_intervals: list[ConfidenceInterval]
+    attribute_rates: list[AttributeBiasRate]
     guardian_interactions: dict[str, list[GuardianInteraction]]
 
 

--- a/fair_forge/schemas/common.py
+++ b/fair_forge/schemas/common.py
@@ -38,6 +38,7 @@ class Batch(BaseModel):
     agentic: dict | None = {}
     ground_truth_agentic: dict | None = {}
     qa_id: str
+    weight: float | None = None
 
 
 class IterationLevel(str, Enum):

--- a/fair_forge/schemas/common.py
+++ b/fair_forge/schemas/common.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Logprobs(BaseModel):
@@ -38,7 +38,7 @@ class Batch(BaseModel):
     agentic: dict | None = {}
     ground_truth_agentic: dict | None = {}
     qa_id: str
-    weight: float | None = None
+    weight: float | None = Field(default=None, ge=0)
 
 
 class IterationLevel(str, Enum):

--- a/fair_forge/schemas/context.py
+++ b/fair_forge/schemas/context.py
@@ -1,14 +1,22 @@
 """Context metric schemas."""
 
+from pydantic import BaseModel
+
 from .metrics import BaseMetric
+
+
+class ContextInteraction(BaseModel):
+    qa_id: str
+    context_awareness: float
 
 
 class ContextMetric(BaseMetric):
     """
-    Context metric for evaluating context awareness.
+    Session-level context metric aggregating context awareness scores across all interactions.
     """
 
-    context_insight: str
+    n_interactions: int
     context_awareness: float
-    context_thinkings: str
-    qa_id: str
+    context_awareness_ci_low: float | None = None
+    context_awareness_ci_high: float | None = None
+    interactions: list[ContextInteraction]

--- a/fair_forge/schemas/conversational.py
+++ b/fair_forge/schemas/conversational.py
@@ -1,20 +1,38 @@
 """Conversational metric schemas."""
 
+from pydantic import BaseModel
+
 from .metrics import BaseMetric
+
+
+class ConversationalScore(BaseModel):
+    mean: float
+    ci_low: float | None = None
+    ci_high: float | None = None
+
+
+class ConversationalInteraction(BaseModel):
+    qa_id: str
+    memory: float
+    language: float
+    quality_maxim: float
+    quantity_maxim: float
+    relation_maxim: float
+    manner_maxim: float
+    sensibleness: float
 
 
 class ConversationalMetric(BaseMetric):
     """
-    Conversational metric for evaluating the assistant's conversational abilities.
+    Session-level conversational metric aggregating Grice's maxim scores across all interactions.
     """
 
-    conversational_memory: float
-    conversational_insight: str
-    conversational_language: float
-    conversational_quality_maxim: float
-    conversational_quantity_maxim: float
-    conversational_relation_maxim: float
-    conversational_manner_maxim: float
-    conversational_sensibleness: float
-    conversational_thinkings: str
-    qa_id: str
+    n_interactions: int
+    conversational_memory: ConversationalScore
+    conversational_language: ConversationalScore
+    conversational_quality_maxim: ConversationalScore
+    conversational_quantity_maxim: ConversationalScore
+    conversational_relation_maxim: ConversationalScore
+    conversational_manner_maxim: ConversationalScore
+    conversational_sensibleness: ConversationalScore
+    interactions: list[ConversationalInteraction]

--- a/fair_forge/schemas/regulatory.py
+++ b/fair_forge/schemas/regulatory.py
@@ -28,22 +28,8 @@ class RegulatoryChunk(BaseModel):
     verdict: Literal["SUPPORTS", "CONTRADICTS"]
 
 
-class RegulatoryMetric(BaseMetric):
-    """
-    Regulatory compliance metric for evaluating assistant responses against regulatory corpus.
-
-    Attributes:
-        qa_id: Unique identifier for the Q&A interaction.
-        query: The user query.
-        assistant: The assistant response.
-        compliance_score: Overall compliance score (0.0-1.0).
-            1.0 = fully supported, 0.0 = fully contradicted.
-        verdict: Overall verdict (COMPLIANT, NON_COMPLIANT, or IRRELEVANT).
-        supporting_chunks: Number of chunks that support the response.
-        contradicting_chunks: Number of chunks that contradict the response.
-        retrieved_chunks: List of retrieved and evaluated chunks.
-        insight: Explanation of the compliance evaluation.
-    """
+class RegulatoryInteraction(BaseModel):
+    """Per-interaction regulatory evaluation result embedded in the session-level metric."""
 
     qa_id: str
     query: str
@@ -56,4 +42,30 @@ class RegulatoryMetric(BaseMetric):
     insight: str
 
 
-__all__ = ["RegulatoryChunk", "RegulatoryMetric"]
+class RegulatoryMetric(BaseMetric):
+    """
+    Session-level regulatory compliance metric aggregating compliance scores
+    across all interactions.
+
+    Attributes:
+        n_interactions: Number of interactions evaluated in this session.
+        compliance_score: Weighted mean compliance score across all interactions (0.0-1.0).
+        compliance_score_ci_low: Lower credible bound — only set in Bayesian mode.
+        compliance_score_ci_high: Upper credible bound — only set in Bayesian mode.
+        verdict: Overall session verdict derived from the aggregated compliance score.
+        total_supporting_chunks: Sum of supporting chunks across all interactions.
+        total_contradicting_chunks: Sum of contradicting chunks across all interactions.
+        interactions: Per-interaction evaluation details.
+    """
+
+    n_interactions: int
+    compliance_score: float = Field(ge=0, le=1)
+    compliance_score_ci_low: float | None = None
+    compliance_score_ci_high: float | None = None
+    verdict: Literal["COMPLIANT", "NON_COMPLIANT", "IRRELEVANT"]
+    total_supporting_chunks: int = Field(ge=0)
+    total_contradicting_chunks: int = Field(ge=0)
+    interactions: list[RegulatoryInteraction]
+
+
+__all__ = ["RegulatoryChunk", "RegulatoryInteraction", "RegulatoryMetric"]

--- a/tests/metrics/test_bias.py
+++ b/tests/metrics/test_bias.py
@@ -5,6 +5,7 @@ import pytest
 from fair_forge.core import Guardian
 from fair_forge.metrics.bias import Bias
 from fair_forge.schemas.bias import BiasMetric, GuardianBias, ProtectedAttribute
+from fair_forge.statistical import BayesianMode, FrequentistMode
 from tests.fixtures.mock_data import create_sample_batch
 from tests.fixtures.mock_retriever import MockRetriever
 
@@ -44,14 +45,14 @@ class TestBiasMetric:
         bias = Bias(retriever=MockRetriever, guardian=MockGuardian)
 
         assert bias.guardian is not None
-        assert bias.confidence_level == 0.95
+        assert isinstance(bias.statistical_mode, FrequentistMode)
         assert len(bias.protected_attributes) == 5
 
-    def test_initialization_custom_confidence(self):
-        """Test Bias initialization with custom confidence level."""
-        bias = Bias(retriever=MockRetriever, guardian=MockGuardian, confidence_level=0.80)
+    def test_initialization_custom_statistical_mode(self):
+        """Test Bias initialization with custom statistical mode."""
+        bias = Bias(retriever=MockRetriever, guardian=MockGuardian, statistical_mode=BayesianMode())
 
-        assert bias.confidence_level == 0.80
+        assert isinstance(bias.statistical_mode, BayesianMode)
 
     def test_protected_attributes_defined(self):
         """Test that all protected attributes are defined."""
@@ -68,41 +69,6 @@ class TestBiasMetric:
         actual_attributes = {attr.attribute for attr in bias.protected_attributes}
         assert actual_attributes == expected_attributes
 
-    def test_clopper_pearson_basic(self):
-        """Test Clopper-Pearson confidence interval calculation."""
-        bias = Bias(retriever=MockRetriever, guardian=MockGuardian, confidence_level=0.95)
-
-        result = bias._clopper_pearson_confidence_interval(samples=100, k_success=70)
-
-        assert result.samples == 100
-        assert result.k_success == 70
-        assert result.probability == pytest.approx(0.7, abs=0.001)
-        assert result.alpha == pytest.approx(0.05, abs=0.001)
-        assert result.lower_bound < result.probability
-        assert result.upper_bound > result.probability
-        assert 0 <= result.lower_bound <= 1
-        assert 0 <= result.upper_bound <= 1
-
-    def test_clopper_pearson_all_success(self):
-        """Test Clopper-Pearson when all samples are successes."""
-        bias = Bias(retriever=MockRetriever, guardian=MockGuardian)
-
-        result = bias._clopper_pearson_confidence_interval(samples=100, k_success=100)
-
-        assert result.probability == 1.0
-        assert result.upper_bound == 1.0
-
-    def test_clopper_pearson_no_success(self):
-        """Test Clopper-Pearson when no samples are successes."""
-        bias = Bias(retriever=MockRetriever, guardian=MockGuardian)
-
-        result = bias._clopper_pearson_confidence_interval(samples=100, k_success=0)
-
-        assert result.probability == 0.0
-        # When k_success=0, lower_bound can be NaN due to beta distribution behavior
-        # The important thing is that upper_bound is valid
-        assert result.upper_bound > 0
-
     def test_get_guardian_biased_attributes(self):
         """Test _get_guardian_biased_attributes method."""
         bias = Bias(retriever=MockRetriever, guardian=MockGuardian)
@@ -116,18 +82,15 @@ class TestBiasMetric:
             batch=batches, attributes=bias.protected_attributes, context="test context"
         )
 
-        # Should have entries for all protected attributes
         assert len(result) == 5
         for attr in bias.protected_attributes:
             assert attr.attribute.value in result
-            # Each attribute should have 2 interactions (one per batch)
             assert len(result[attr.attribute.value]) == 2
 
-    def test_calculate_confidence_intervals(self):
-        """Test _calculate_confidence_intervals method."""
+    def test_calculate_attribute_rates_frequentist(self):
+        """Test _calculate_attribute_rates with frequentist mode."""
         bias = Bias(retriever=MockRetriever, guardian=MockGuardian)
 
-        # Create mock biases_by_attributes
         biases_by_attributes = {}
         for attr in bias.protected_attributes:
             biases_by_attributes[attr.attribute.value] = [
@@ -139,14 +102,40 @@ class TestBiasMetric:
                 ),
             ]
 
-        result = bias._calculate_confidence_intervals(biases_by_attributes)
+        result = bias._calculate_attribute_rates(biases_by_attributes)
 
         assert len(result) == 5
-        for interval in result:
-            assert isinstance(interval, BiasMetric.ConfidenceInterval)
-            assert interval.samples == 2
-            assert interval.k_success == 2  # Both not biased
-            assert interval.confidence_level == 0.95
+        for rate in result:
+            assert isinstance(rate, BiasMetric.AttributeBiasRate)
+            assert rate.n_samples == 2
+            assert rate.k_biased == 0
+            assert rate.rate == 0.0
+            assert rate.ci_low is None
+            assert rate.ci_high is None
+
+    def test_calculate_attribute_rates_bayesian(self):
+        """Test _calculate_attribute_rates with Bayesian mode."""
+        bias = Bias(retriever=MockRetriever, guardian=MockGuardian, statistical_mode=BayesianMode(mc_samples=100))
+
+        biases_by_attributes = {}
+        for attr in bias.protected_attributes:
+            biases_by_attributes[attr.attribute.value] = [
+                BiasMetric.GuardianInteraction(
+                    qa_id="qa_001", is_biased=True, attribute=attr.attribute.value, certainty=0.9
+                ),
+                BiasMetric.GuardianInteraction(
+                    qa_id="qa_002", is_biased=False, attribute=attr.attribute.value, certainty=0.85
+                ),
+            ]
+
+        result = bias._calculate_attribute_rates(biases_by_attributes)
+
+        assert len(result) == 5
+        for rate in result:
+            assert isinstance(rate, BiasMetric.AttributeBiasRate)
+            assert rate.ci_low is not None
+            assert rate.ci_high is not None
+            assert rate.ci_low <= rate.rate <= rate.ci_high
 
     def test_batch_processing(self):
         """Test batch method processes correctly."""
@@ -164,7 +153,7 @@ class TestBiasMetric:
         assert isinstance(metric, BiasMetric)
         assert metric.session_id == "test_session"
         assert metric.assistant_id == "test_assistant"
-        assert len(metric.confidence_intervals) == 5
+        assert len(metric.attribute_rates) == 5
         assert len(metric.guardian_interactions) == 5
 
     def test_batch_multiple_interactions(self):
@@ -177,7 +166,6 @@ class TestBiasMetric:
 
         assert len(bias.metrics) == 1
         metric = bias.metrics[0]
-        # Each attribute should have 5 interactions
         for attr_key, interactions in metric.guardian_interactions.items():
             assert len(interactions) == 5
 
@@ -190,16 +178,14 @@ class TestBiasMetric:
         bias.batch(session_id="test_session", context="test context", assistant_id="test_assistant", batch=batches)
 
         metric = bias.metrics[0]
-        # Check that some interactions are biased and some are not
         for attr_key, interactions in metric.guardian_interactions.items():
             biased_count = sum(1 for i in interactions if i.is_biased)
             not_biased_count = sum(1 for i in interactions if not i.is_biased)
-            # With 4 batches and 5 attributes, we should have a mix
             assert biased_count + not_biased_count == 4
 
-    def test_confidence_interval_calculation_with_biased(self):
-        """Test confidence interval calculation when some responses are biased."""
-        bias = Bias(retriever=MockRetriever, guardian=MockGuardianAlternating, confidence_level=0.90)
+    def test_bias_rate_with_mixed_results(self):
+        """Test bias rate calculation when some responses are biased."""
+        bias = Bias(retriever=MockRetriever, guardian=MockGuardianAlternating)
 
         biases_by_attributes = {}
         for attr in bias.protected_attributes:
@@ -218,12 +204,12 @@ class TestBiasMetric:
                 ),
             ]
 
-        result = bias._calculate_confidence_intervals(biases_by_attributes)
+        result = bias._calculate_attribute_rates(biases_by_attributes)
 
-        for interval in result:
-            assert interval.samples == 4
-            assert interval.k_success == 2  # 2 not biased out of 4
-            assert interval.probability == pytest.approx(0.5, abs=0.001)
+        for rate in result:
+            assert rate.n_samples == 4
+            assert rate.k_biased == 2
+            assert rate.rate == pytest.approx(0.5, abs=0.001)
 
     def test_verbose_mode(self):
         """Test that verbose mode doesn't break initialization."""

--- a/tests/metrics/test_context.py
+++ b/tests/metrics/test_context.py
@@ -6,6 +6,7 @@ import pytest
 
 from fair_forge.metrics.context import Context
 from fair_forge.schemas.context import ContextMetric
+from fair_forge.statistical import BayesianMode, FrequentistMode
 from tests.fixtures.mock_data import create_sample_batch
 from tests.fixtures.mock_retriever import ContextDatasetRetriever, MockRetriever
 
@@ -15,20 +16,18 @@ class TestContextMetric:
 
     @pytest.fixture
     def mock_model(self):
-        """Create a mock BaseChatModel."""
         return MagicMock()
 
     def test_initialization_default(self, mock_model):
-        """Test Context initialization with default parameters."""
         context = Context(retriever=MockRetriever, model=mock_model)
 
         assert context.model == mock_model
+        assert isinstance(context.statistical_mode, FrequentistMode)
         assert context.use_structured_output is False
         assert context.bos_json_clause == "```json"
         assert context.eos_json_clause == "```"
 
     def test_initialization_custom(self, mock_model):
-        """Test Context initialization with custom parameters."""
         context = Context(
             retriever=MockRetriever,
             model=mock_model,
@@ -37,136 +36,122 @@ class TestContextMetric:
             eos_json_clause="</json>",
         )
 
-        assert context.model == mock_model
         assert context.use_structured_output is True
         assert context.bos_json_clause == "<json>"
         assert context.eos_json_clause == "</json>"
 
+    def test_initialization_bayesian(self, mock_model):
+        context = Context(
+            retriever=MockRetriever,
+            model=mock_model,
+            statistical_mode=BayesianMode(mc_samples=100),
+        )
+        assert isinstance(context.statistical_mode, BayesianMode)
+
     @patch("fair_forge.metrics.context.Judge")
     def test_batch_processing(self, mock_judge_class, mock_model):
-        """Test batch method processes interactions correctly."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "I analyzed the context...",
-            {"insight": "Good context awareness", "score": 0.85},
-        )
+        mock_judge.check.return_value = ("I analyzed the context...", {"insight": "Good context awareness", "score": 0.85})
 
         context = Context(retriever=MockRetriever, model=mock_model)
+        batches = [create_sample_batch(qa_id="qa_001"), create_sample_batch(qa_id="qa_002")]
+        context.batch(session_id="test_session", context="Healthcare AI context", assistant_id="test_assistant", batch=batches)
+        context.on_process_complete()
 
-        batches = [
-            create_sample_batch(qa_id="qa_001"),
-            create_sample_batch(qa_id="qa_002"),
-        ]
+        assert len(context.metrics) == 1
+        metric = context.metrics[0]
+        assert isinstance(metric, ContextMetric)
+        assert metric.session_id == "test_session"
+        assert metric.n_interactions == 2
+        assert metric.context_awareness == pytest.approx(0.85)
+        assert metric.context_awareness_ci_low is None
+        assert metric.context_awareness_ci_high is None
+        assert len(metric.interactions) == 2
+        assert metric.interactions[0].qa_id == "qa_001"
+        assert metric.interactions[0].context_awareness == pytest.approx(0.85)
 
-        context.batch(
-            session_id="test_session",
-            context="Healthcare AI context",
-            assistant_id="test_assistant",
-            batch=batches,
-            language="english",
-        )
+    @patch("fair_forge.metrics.context.Judge")
+    def test_batch_session_accumulation(self, mock_judge_class, mock_model):
+        mock_judge = MagicMock()
+        mock_judge_class.return_value = mock_judge
+        mock_judge.check.return_value = ("", {"insight": "ok", "score": 0.8})
+
+        context = Context(retriever=MockRetriever, model=mock_model)
+        context.batch(session_id="s1", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="q1")])
+        context.batch(session_id="s1", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="q2")])
+        context.on_process_complete()
+
+        assert len(context.metrics) == 1
+        assert context.metrics[0].n_interactions == 2
+
+    @patch("fair_forge.metrics.context.Judge")
+    def test_batch_multiple_sessions(self, mock_judge_class, mock_model):
+        mock_judge = MagicMock()
+        mock_judge_class.return_value = mock_judge
+        mock_judge.check.return_value = ("", {"insight": "ok", "score": 0.7})
+
+        context = Context(retriever=MockRetriever, model=mock_model)
+        context.batch(session_id="s1", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="q1")])
+        context.batch(session_id="s2", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="q2")])
+        context.on_process_complete()
 
         assert len(context.metrics) == 2
-        assert all(isinstance(m, ContextMetric) for m in context.metrics)
-        assert context.metrics[0].session_id == "test_session"
-        assert context.metrics[0].qa_id == "qa_001"
-        assert context.metrics[0].context_awareness == 0.85
-        assert context.metrics[0].context_insight == "Good context awareness"
-        assert context.metrics[0].context_thinkings == "I analyzed the context..."
 
     @patch("fair_forge.metrics.context.Judge")
     def test_batch_with_observation(self, mock_judge_class, mock_model):
-        """Test batch method handles observation correctly."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "Observation analysis...",
-            {"insight": "With observation", "score": 0.9},
-        )
+        mock_judge.check.return_value = ("Observation analysis...", {"insight": "With observation", "score": 0.9})
 
         context = Context(retriever=MockRetriever, model=mock_model)
-
         batch = create_sample_batch(qa_id="qa_001", observation="The user seems confused")
+        context.batch(session_id="test_session", context="Test context", assistant_id="test_assistant", batch=[batch])
 
-        context.batch(
-            session_id="test_session",
-            context="Test context",
-            assistant_id="test_assistant",
-            batch=[batch],
-        )
-
-        # Verify judge was called with observation data
-        assert mock_judge.check.called
         call_args = mock_judge.check.call_args
         assert "observation" in call_args[0][2]
 
     @patch("fair_forge.metrics.context.Judge")
     def test_batch_without_observation(self, mock_judge_class, mock_model):
-        """Test batch method handles case without observation."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "Analysis without observation...",
-            {"insight": "Without observation", "score": 0.8},
-        )
+        mock_judge.check.return_value = ("Analysis without observation...", {"insight": "Without observation", "score": 0.8})
 
         context = Context(retriever=MockRetriever, model=mock_model)
-
         batch = create_sample_batch(qa_id="qa_001", observation=None)
+        context.batch(session_id="test_session", context="Test context", assistant_id="test_assistant", batch=[batch])
 
-        context.batch(
-            session_id="test_session",
-            context="Test context",
-            assistant_id="test_assistant",
-            batch=[batch],
-        )
-
-        # Verify judge was called with ground_truth_assistant
         call_args = mock_judge.check.call_args
         assert "ground_truth_assistant" in call_args[0][2]
 
     @patch("fair_forge.metrics.context.Judge")
     def test_batch_raises_on_no_result(self, mock_judge_class, mock_model):
-        """Test batch raises ValueError when no result is returned."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
         mock_judge.check.return_value = ("Some thinking", None)
 
         context = Context(retriever=MockRetriever, model=mock_model)
-
-        batch = create_sample_batch(qa_id="qa_001")
-
         with pytest.raises(ValueError, match="No valid response"):
             context.batch(
                 session_id="test_session",
                 context="Test context",
                 assistant_id="test_assistant",
-                batch=[batch],
+                batch=[create_sample_batch(qa_id="qa_001")],
             )
 
     @patch("fair_forge.metrics.context.Judge")
     def test_run_method(self, mock_judge_class, mock_model):
-        """Test the run class method."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "Thinking...",
-            {"insight": "Test insight", "score": 0.75},
-        )
+        mock_judge.check.return_value = ("Thinking...", {"insight": "Test insight", "score": 0.75})
 
-        metrics = Context.run(
-            ContextDatasetRetriever,
-            model=mock_model,
-            verbose=False,
-        )
+        metrics = Context.run(ContextDatasetRetriever, model=mock_model, verbose=False)
 
         assert len(metrics) > 0
         assert all(isinstance(m, ContextMetric) for m in metrics)
 
     @patch("fair_forge.metrics.context.Judge")
     def test_judge_initialization_params(self, mock_judge_class, mock_model):
-        """Test that Judge is initialized with correct parameters."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
         mock_judge.check.return_value = ("", {"insight": "test", "score": 0.5})
@@ -178,14 +163,7 @@ class TestContextMetric:
             bos_json_clause="[",
             eos_json_clause="]",
         )
-
-        batch = create_sample_batch(qa_id="qa_001")
-        context.batch(
-            session_id="s",
-            context="c",
-            assistant_id="a",
-            batch=[batch],
-        )
+        context.batch(session_id="s", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="qa_001")])
 
         mock_judge_class.assert_called_once_with(
             model=mock_model,
@@ -197,51 +175,48 @@ class TestContextMetric:
 
     @patch("fair_forge.metrics.context.Judge")
     def test_verbose_mode(self, mock_judge_class, mock_model):
-        """Test that verbose mode doesn't break processing."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "Thinking...",
-            {"insight": "Test", "score": 0.8},
-        )
+        mock_judge.check.return_value = ("Thinking...", {"insight": "Test", "score": 0.8})
 
         context = Context(retriever=MockRetriever, model=mock_model, verbose=True)
-
-        batch = create_sample_batch(qa_id="qa_001")
-        context.batch(
-            session_id="s",
-            context="c",
-            assistant_id="a",
-            batch=[batch],
-        )
+        context.batch(session_id="s", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="qa_001")])
+        context.on_process_complete()
 
         assert len(context.metrics) == 1
 
     @patch("fair_forge.metrics.context.Judge")
     def test_structured_output_mode(self, mock_judge_class, mock_model):
-        """Test Context with structured output enabled."""
         from fair_forge.llm.schemas import ContextJudgeOutput
 
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-
         expected_result = ContextJudgeOutput(score=0.85, insight="Good context")
         mock_judge.check.return_value = ("", expected_result)
+
+        context = Context(retriever=MockRetriever, model=mock_model, use_structured_output=True)
+        context.batch(session_id="test_session", context="Test context", assistant_id="test_assistant", batch=[create_sample_batch(qa_id="qa_001")])
+        context.on_process_complete()
+
+        assert len(context.metrics) == 1
+        assert context.metrics[0].context_awareness == pytest.approx(0.85)
+
+    @patch("fair_forge.metrics.context.Judge")
+    def test_bayesian_mode_produces_ci(self, mock_judge_class, mock_model):
+        mock_judge = MagicMock()
+        mock_judge_class.return_value = mock_judge
+        mock_judge.check.return_value = ("", {"insight": "ok", "score": 0.8})
 
         context = Context(
             retriever=MockRetriever,
             model=mock_model,
-            use_structured_output=True,
+            statistical_mode=BayesianMode(mc_samples=200, rng_seed=42),
         )
+        batches = [create_sample_batch(qa_id=f"q{i}") for i in range(3)]
+        context.batch(session_id="s", context="c", assistant_id="a", batch=batches)
+        context.on_process_complete()
 
-        batch = create_sample_batch(qa_id="qa_001")
-        context.batch(
-            session_id="test_session",
-            context="Test context",
-            assistant_id="test_assistant",
-            batch=[batch],
-        )
-
-        assert len(context.metrics) == 1
-        assert context.metrics[0].context_awareness == 0.85
-        assert context.metrics[0].context_insight == "Good context"
+        metric = context.metrics[0]
+        assert metric.context_awareness_ci_low is not None
+        assert metric.context_awareness_ci_high is not None
+        assert metric.context_awareness_ci_low <= metric.context_awareness <= metric.context_awareness_ci_high

--- a/tests/metrics/test_conversational.py
+++ b/tests/metrics/test_conversational.py
@@ -5,9 +5,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from fair_forge.metrics.conversational import Conversational
-from fair_forge.schemas.conversational import ConversationalMetric
+from fair_forge.schemas.conversational import ConversationalMetric, ConversationalScore
+from fair_forge.statistical import BayesianMode, FrequentistMode
 from tests.fixtures.mock_data import create_sample_batch
 from tests.fixtures.mock_retriever import ConversationalDatasetRetriever, MockRetriever
+
+MOCK_JUDGE_RESULT = {
+    "insight": "Good conversation quality",
+    "memory": 0.9,
+    "language": 0.85,
+    "quality_maxim": 0.8,
+    "quantity_maxim": 0.75,
+    "relation_maxim": 0.9,
+    "manner_maxim": 0.85,
+    "sensibleness": 0.88,
+}
 
 
 class TestConversationalMetric:
@@ -15,20 +27,18 @@ class TestConversationalMetric:
 
     @pytest.fixture
     def mock_model(self):
-        """Create a mock BaseChatModel."""
         return MagicMock()
 
     def test_initialization_default(self, mock_model):
-        """Test Conversational initialization with default parameters."""
         conv = Conversational(retriever=MockRetriever, model=mock_model)
 
         assert conv.model == mock_model
+        assert isinstance(conv.statistical_mode, FrequentistMode)
         assert conv.use_structured_output is False
         assert conv.bos_json_clause == "```json"
         assert conv.eos_json_clause == "```"
 
     def test_initialization_custom(self, mock_model):
-        """Test Conversational initialization with custom parameters."""
         conv = Conversational(
             retriever=MockRetriever,
             model=mock_model,
@@ -37,194 +47,134 @@ class TestConversationalMetric:
             eos_json_clause="</json>",
         )
 
-        assert conv.model == mock_model
         assert conv.use_structured_output is True
         assert conv.bos_json_clause == "<json>"
         assert conv.eos_json_clause == "</json>"
 
+    def test_initialization_bayesian(self, mock_model):
+        conv = Conversational(
+            retriever=MockRetriever,
+            model=mock_model,
+            statistical_mode=BayesianMode(mc_samples=100),
+        )
+        assert isinstance(conv.statistical_mode, BayesianMode)
+
     @patch("fair_forge.metrics.conversational.Judge")
     def test_batch_processing(self, mock_judge_class, mock_model):
-        """Test batch method processes interactions correctly."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "I analyzed the conversation...",
-            {
-                "insight": "Good conversation quality",
-                "memory": 0.9,
-                "language": 0.85,
-                "quality_maxim": 0.8,
-                "quantity_maxim": 0.75,
-                "relation_maxim": 0.9,
-                "manner_maxim": 0.85,
-                "sensibleness": 0.88,
-            },
-        )
+        mock_judge.check.return_value = ("I analyzed the conversation...", MOCK_JUDGE_RESULT)
 
         conv = Conversational(retriever=MockRetriever, model=mock_model)
 
-        batches = [
-            create_sample_batch(qa_id="qa_001"),
-            create_sample_batch(qa_id="qa_002"),
-        ]
+        batches = [create_sample_batch(qa_id="qa_001"), create_sample_batch(qa_id="qa_002")]
+        conv.batch(session_id="test_session", context="Test context", assistant_id="test_assistant", batch=batches)
+        conv.on_process_complete()
 
-        conv.batch(
-            session_id="test_session",
-            context="Test context",
-            assistant_id="test_assistant",
-            batch=batches,
-            language="english",
-        )
+        assert len(conv.metrics) == 1
+        metric = conv.metrics[0]
+        assert isinstance(metric, ConversationalMetric)
+        assert metric.session_id == "test_session"
+        assert metric.n_interactions == 2
+        assert isinstance(metric.conversational_memory, ConversationalScore)
+        assert metric.conversational_memory.mean == pytest.approx(0.9)
+        assert metric.conversational_memory.ci_low is None
+        assert metric.conversational_language.mean == pytest.approx(0.85)
+        assert metric.conversational_quality_maxim.mean == pytest.approx(0.8)
+        assert metric.conversational_quantity_maxim.mean == pytest.approx(0.75)
+        assert metric.conversational_relation_maxim.mean == pytest.approx(0.9)
+        assert metric.conversational_manner_maxim.mean == pytest.approx(0.85)
+        assert metric.conversational_sensibleness.mean == pytest.approx(0.88)
+        assert len(metric.interactions) == 2
+        assert metric.interactions[0].qa_id == "qa_001"
+        assert metric.interactions[0].memory == pytest.approx(0.9)
+
+    @patch("fair_forge.metrics.conversational.Judge")
+    def test_batch_session_accumulation(self, mock_judge_class, mock_model):
+        """Two separate batch() calls for the same session_id → one metric."""
+        mock_judge = MagicMock()
+        mock_judge_class.return_value = mock_judge
+        mock_judge.check.return_value = ("", MOCK_JUDGE_RESULT)
+
+        conv = Conversational(retriever=MockRetriever, model=mock_model)
+        conv.batch(session_id="s1", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="q1")])
+        conv.batch(session_id="s1", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="q2")])
+        conv.on_process_complete()
+
+        assert len(conv.metrics) == 1
+        assert conv.metrics[0].n_interactions == 2
+
+    @patch("fair_forge.metrics.conversational.Judge")
+    def test_batch_multiple_sessions(self, mock_judge_class, mock_model):
+        """Different session_ids → separate metrics."""
+        mock_judge = MagicMock()
+        mock_judge_class.return_value = mock_judge
+        mock_judge.check.return_value = ("", MOCK_JUDGE_RESULT)
+
+        conv = Conversational(retriever=MockRetriever, model=mock_model)
+        conv.batch(session_id="s1", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="q1")])
+        conv.batch(session_id="s2", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="q2")])
+        conv.on_process_complete()
 
         assert len(conv.metrics) == 2
-        assert all(isinstance(m, ConversationalMetric) for m in conv.metrics)
-
-        metric = conv.metrics[0]
-        assert metric.session_id == "test_session"
-        assert metric.qa_id == "qa_001"
-        assert metric.conversational_memory == 0.9
-        assert metric.conversational_language == 0.85
-        assert metric.conversational_quality_maxim == 0.8
-        assert metric.conversational_quantity_maxim == 0.75
-        assert metric.conversational_relation_maxim == 0.9
-        assert metric.conversational_manner_maxim == 0.85
-        assert metric.conversational_sensibleness == 0.88
-        assert metric.conversational_thinkings == "I analyzed the conversation..."
 
     @patch("fair_forge.metrics.conversational.Judge")
     def test_batch_with_observation(self, mock_judge_class, mock_model):
-        """Test batch method handles observation correctly."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "Observation analysis...",
-            {
-                "insight": "With observation",
-                "memory": 0.9,
-                "language": 0.85,
-                "quality_maxim": 0.8,
-                "quantity_maxim": 0.75,
-                "relation_maxim": 0.9,
-                "manner_maxim": 0.85,
-                "sensibleness": 0.88,
-            },
-        )
+        mock_judge.check.return_value = ("Observation analysis...", MOCK_JUDGE_RESULT)
 
         conv = Conversational(retriever=MockRetriever, model=mock_model)
-
         batch = create_sample_batch(qa_id="qa_001", observation="The user seems satisfied")
+        conv.batch(session_id="test_session", context="Test context", assistant_id="test_assistant", batch=[batch])
 
-        conv.batch(
-            session_id="test_session",
-            context="Test context",
-            assistant_id="test_assistant",
-            batch=[batch],
-        )
-
-        # Verify judge was called with observation data
-        assert mock_judge.check.called
         call_args = mock_judge.check.call_args
         assert "observation" in call_args[0][2]
 
     @patch("fair_forge.metrics.conversational.Judge")
     def test_batch_without_observation(self, mock_judge_class, mock_model):
-        """Test batch method handles case without observation."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "Analysis without observation...",
-            {
-                "insight": "Without observation",
-                "memory": 0.9,
-                "language": 0.85,
-                "quality_maxim": 0.8,
-                "quantity_maxim": 0.75,
-                "relation_maxim": 0.9,
-                "manner_maxim": 0.85,
-                "sensibleness": 0.88,
-            },
-        )
+        mock_judge.check.return_value = ("Analysis without observation...", MOCK_JUDGE_RESULT)
 
         conv = Conversational(retriever=MockRetriever, model=mock_model)
-
         batch = create_sample_batch(qa_id="qa_001", observation=None)
+        conv.batch(session_id="test_session", context="Test context", assistant_id="test_assistant", batch=[batch])
 
-        conv.batch(
-            session_id="test_session",
-            context="Test context",
-            assistant_id="test_assistant",
-            batch=[batch],
-        )
-
-        # Verify judge was called with ground_truth_assistant
         call_args = mock_judge.check.call_args
         assert "ground_truth_assistant" in call_args[0][2]
 
     @patch("fair_forge.metrics.conversational.Judge")
     def test_batch_raises_on_no_result(self, mock_judge_class, mock_model):
-        """Test batch raises ValueError when no result is returned."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
         mock_judge.check.return_value = ("Some thinking", None)
 
         conv = Conversational(retriever=MockRetriever, model=mock_model)
-
-        batch = create_sample_batch(qa_id="qa_001")
-
         with pytest.raises(ValueError, match="No valid response"):
             conv.batch(
                 session_id="test_session",
                 context="Test context",
                 assistant_id="test_assistant",
-                batch=[batch],
+                batch=[create_sample_batch(qa_id="qa_001")],
             )
 
     @patch("fair_forge.metrics.conversational.Judge")
     def test_run_method(self, mock_judge_class, mock_model):
-        """Test the run class method."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "Thinking...",
-            {
-                "insight": "Test insight",
-                "memory": 0.9,
-                "language": 0.85,
-                "quality_maxim": 0.8,
-                "quantity_maxim": 0.75,
-                "relation_maxim": 0.9,
-                "manner_maxim": 0.85,
-                "sensibleness": 0.88,
-            },
-        )
+        mock_judge.check.return_value = ("Thinking...", MOCK_JUDGE_RESULT)
 
-        metrics = Conversational.run(
-            ConversationalDatasetRetriever,
-            model=mock_model,
-            verbose=False,
-        )
+        metrics = Conversational.run(ConversationalDatasetRetriever, model=mock_model, verbose=False)
 
         assert len(metrics) > 0
         assert all(isinstance(m, ConversationalMetric) for m in metrics)
 
     @patch("fair_forge.metrics.conversational.Judge")
     def test_judge_initialization_params(self, mock_judge_class, mock_model):
-        """Test that Judge is initialized with correct parameters."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "",
-            {
-                "insight": "test",
-                "memory": 0.5,
-                "language": 0.5,
-                "quality_maxim": 0.5,
-                "quantity_maxim": 0.5,
-                "relation_maxim": 0.5,
-                "manner_maxim": 0.5,
-                "sensibleness": 0.5,
-            },
-        )
+        mock_judge.check.return_value = ("", MOCK_JUDGE_RESULT)
 
         conv = Conversational(
             retriever=MockRetriever,
@@ -233,14 +183,7 @@ class TestConversationalMetric:
             bos_json_clause="[",
             eos_json_clause="]",
         )
-
-        batch = create_sample_batch(qa_id="qa_001")
-        conv.batch(
-            session_id="s",
-            context="c",
-            assistant_id="a",
-            batch=[batch],
-        )
+        conv.batch(session_id="s", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="qa_001")])
 
         mock_judge_class.assert_called_once_with(
             model=mock_model,
@@ -251,104 +194,71 @@ class TestConversationalMetric:
 
     @patch("fair_forge.metrics.conversational.Judge")
     def test_language_parameter(self, mock_judge_class, mock_model):
-        """Test that language parameter is passed correctly."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "",
-            {
-                "insight": "test",
-                "memory": 0.5,
-                "language": 0.5,
-                "quality_maxim": 0.5,
-                "quantity_maxim": 0.5,
-                "relation_maxim": 0.5,
-                "manner_maxim": 0.5,
-                "sensibleness": 0.5,
-            },
-        )
+        mock_judge.check.return_value = ("", MOCK_JUDGE_RESULT)
 
         conv = Conversational(retriever=MockRetriever, model=mock_model)
+        conv.batch(session_id="s", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="qa_001")], language="spanish")
 
-        batch = create_sample_batch(qa_id="qa_001")
-        conv.batch(
-            session_id="s",
-            context="c",
-            assistant_id="a",
-            batch=[batch],
-            language="spanish",
-        )
-
-        # Verify preferred_language was passed
         call_args = mock_judge.check.call_args
         assert call_args[0][2]["preferred_language"] == "spanish"
 
     @patch("fair_forge.metrics.conversational.Judge")
     def test_verbose_mode(self, mock_judge_class, mock_model):
-        """Test that verbose mode doesn't break processing."""
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-        mock_judge.check.return_value = (
-            "Thinking...",
-            {
-                "insight": "Test",
-                "memory": 0.9,
-                "language": 0.85,
-                "quality_maxim": 0.8,
-                "quantity_maxim": 0.75,
-                "relation_maxim": 0.9,
-                "manner_maxim": 0.85,
-                "sensibleness": 0.88,
-            },
-        )
+        mock_judge.check.return_value = ("Thinking...", MOCK_JUDGE_RESULT)
 
         conv = Conversational(retriever=MockRetriever, model=mock_model, verbose=True)
-
-        batch = create_sample_batch(qa_id="qa_001")
-        conv.batch(
-            session_id="s",
-            context="c",
-            assistant_id="a",
-            batch=[batch],
-        )
+        conv.batch(session_id="s", context="c", assistant_id="a", batch=[create_sample_batch(qa_id="qa_001")])
+        conv.on_process_complete()
 
         assert len(conv.metrics) == 1
 
     @patch("fair_forge.metrics.conversational.Judge")
     def test_structured_output_mode(self, mock_judge_class, mock_model):
-        """Test Conversational with structured output enabled."""
         from fair_forge.llm.schemas import ConversationalJudgeOutput
 
         mock_judge = MagicMock()
         mock_judge_class.return_value = mock_judge
-
         expected_result = ConversationalJudgeOutput(
-            memory=8.5,
-            language=9.0,
-            insight="Good conversation",
-            quality_maxim=8.0,
-            quantity_maxim=7.5,
-            relation_maxim=9.0,
-            manner_maxim=8.5,
-            sensibleness=9.0,
+            memory=8.5, language=9.0, insight="Good conversation",
+            quality_maxim=8.0, quantity_maxim=7.5, relation_maxim=9.0,
+            manner_maxim=8.5, sensibleness=9.0,
         )
         mock_judge.check.return_value = ("", expected_result)
+
+        conv = Conversational(retriever=MockRetriever, model=mock_model, use_structured_output=True)
+        conv.batch(session_id="test_session", context="Test context", assistant_id="test_assistant", batch=[create_sample_batch(qa_id="qa_001")])
+        conv.on_process_complete()
+
+        assert len(conv.metrics) == 1
+        assert conv.metrics[0].conversational_memory.mean == pytest.approx(8.5)
+        assert conv.metrics[0].conversational_language.mean == pytest.approx(9.0)
+
+    @patch("fair_forge.metrics.conversational.Judge")
+    def test_bayesian_mode_produces_ci(self, mock_judge_class, mock_model):
+        mock_judge = MagicMock()
+        mock_judge_class.return_value = mock_judge
+        varying_results = [
+            {**MOCK_JUDGE_RESULT, "memory": 0.6},
+            {**MOCK_JUDGE_RESULT, "memory": 0.8},
+            {**MOCK_JUDGE_RESULT, "memory": 1.0},
+        ]
+        mock_judge.check.side_effect = [("", r) for r in varying_results]
 
         conv = Conversational(
             retriever=MockRetriever,
             model=mock_model,
-            use_structured_output=True,
+            statistical_mode=BayesianMode(mc_samples=500, rng_seed=42),
         )
+        batches = [create_sample_batch(qa_id=f"q{i}") for i in range(3)]
+        conv.batch(session_id="s", context="c", assistant_id="a", batch=batches)
+        conv.on_process_complete()
 
-        batch = create_sample_batch(qa_id="qa_001")
-        conv.batch(
-            session_id="test_session",
-            context="Test context",
-            assistant_id="test_assistant",
-            batch=[batch],
-        )
-
-        assert len(conv.metrics) == 1
-        assert conv.metrics[0].conversational_memory == 8.5
-        assert conv.metrics[0].conversational_language == 9.0
-        assert conv.metrics[0].conversational_insight == "Good conversation"
+        metric = conv.metrics[0]
+        assert metric.conversational_memory.ci_low is not None
+        assert metric.conversational_memory.ci_high is not None
+        assert metric.conversational_memory.ci_low <= metric.conversational_memory.mean
+        assert metric.conversational_memory.mean <= metric.conversational_memory.ci_high

--- a/tests/metrics/test_regulatory.py
+++ b/tests/metrics/test_regulatory.py
@@ -12,7 +12,7 @@ from fair_forge.connectors import LocalCorpusConnector, RegulatoryDocument
 from fair_forge.core.embedder import EmbedderConfig, RegulatoryEmbedder, RetrievedChunk
 from fair_forge.core.reranker import RankedChunk, RerankerConfig, RegulatoryReranker
 from fair_forge.metrics.regulatory import Regulatory
-from fair_forge.schemas.regulatory import RegulatoryChunk, RegulatoryMetric
+from fair_forge.schemas.regulatory import RegulatoryChunk, RegulatoryInteraction, RegulatoryMetric
 
 
 class MockCorpusConnector:
@@ -53,9 +53,7 @@ class TestRegulatoryMetricSchema:
         assert chunk.verdict == "SUPPORTS"
 
     def test_regulatory_metric_creation(self):
-        metric = RegulatoryMetric(
-            session_id="test_session",
-            assistant_id="test_assistant",
+        interaction = RegulatoryInteraction(
             qa_id="qa_001",
             query="Test query",
             assistant="Test response",
@@ -66,8 +64,19 @@ class TestRegulatoryMetricSchema:
             retrieved_chunks=[],
             insight="Test insight",
         )
+        metric = RegulatoryMetric(
+            session_id="test_session",
+            assistant_id="test_assistant",
+            n_interactions=1,
+            compliance_score=0.8,
+            verdict="COMPLIANT",
+            total_supporting_chunks=2,
+            total_contradicting_chunks=0,
+            interactions=[interaction],
+        )
         assert metric.compliance_score == 0.8
         assert metric.verdict == "COMPLIANT"
+        assert metric.interactions[0].qa_id == "qa_001"
 
 
 class TestLocalCorpusConnector:
@@ -185,13 +194,15 @@ class TestRegulatoryMetric:
             batch=dataset.conversation,
             language=dataset.language,
         )
+        metric.on_process_complete()
 
-        assert len(metric.metrics) == len(dataset.conversation)
-
-        for m in metric.metrics:
-            assert isinstance(m, RegulatoryMetric)
-            assert hasattr(m, "compliance_score")
-            assert hasattr(m, "verdict")
+        assert len(metric.metrics) == 1
+        m = metric.metrics[0]
+        assert isinstance(m, RegulatoryMetric)
+        assert m.n_interactions == len(dataset.conversation)
+        assert hasattr(m, "compliance_score")
+        assert hasattr(m, "verdict")
+        assert len(m.interactions) == len(dataset.conversation)
 
     @patch.object(RegulatoryEmbedder, "retrieve_merged")
     @patch.object(RegulatoryReranker, "check_contradictions")
@@ -241,10 +252,11 @@ class TestRegulatoryMetric:
             batch=dataset.conversation[:1],
             language=dataset.language,
         )
+        metric.on_process_complete()
 
         assert len(metric.metrics) == 1
         assert metric.metrics[0].verdict == "NON_COMPLIANT"
-        assert metric.metrics[0].contradicting_chunks == 1
+        assert metric.metrics[0].total_contradicting_chunks == 1
 
     @patch.object(RegulatoryEmbedder, "retrieve_merged")
     @patch.object(RegulatoryEmbedder, "load_corpus")
@@ -273,10 +285,11 @@ class TestRegulatoryMetric:
             batch=dataset.conversation[:1],
             language=dataset.language,
         )
+        metric.on_process_complete()
 
         assert len(metric.metrics) == 1
         assert metric.metrics[0].verdict == "IRRELEVANT"
-        assert metric.metrics[0].compliance_score == 0.5
+        assert metric.metrics[0].interactions[0].compliance_score == 0.5
 
     @patch.object(RegulatoryEmbedder, "retrieve_merged")
     @patch.object(RegulatoryReranker, "check_contradictions")
@@ -360,19 +373,22 @@ class TestRegulatoryMetric:
                     required_attributes = [
                         "session_id",
                         "assistant_id",
-                        "qa_id",
-                        "query",
-                        "assistant",
+                        "n_interactions",
                         "compliance_score",
                         "verdict",
-                        "supporting_chunks",
-                        "contradicting_chunks",
-                        "retrieved_chunks",
-                        "insight",
+                        "total_supporting_chunks",
+                        "total_contradicting_chunks",
+                        "interactions",
                     ]
 
                     for attr in required_attributes:
                         assert hasattr(m, attr), f"Missing attribute: {attr}"
+
+                    assert len(m.interactions) > 0
+                    interaction = m.interactions[0]
+                    for attr in ["qa_id", "query", "assistant", "compliance_score", "verdict",
+                                 "supporting_chunks", "contradicting_chunks", "retrieved_chunks", "insight"]:
+                        assert hasattr(interaction, attr), f"Missing interaction attribute: {attr}"
 
 
 class TestComplianceScoring:

--- a/uv.lock
+++ b/uv.lock
@@ -185,7 +185,7 @@ wheels = [
 
 [[package]]
 name = "alquimia-fair-forge"
-version = "1.2.0b7"
+version = "1.3.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Adds pluggable **statistical mode** support across all metrics, enabling either frequentist (point estimates) or Bayesian (credible intervals via bootstrap/posterior) aggregation strategies.

### Bias & Agentic

- **Bias**: replaces hardcoded Clopper-Pearson with a pluggable `StatisticalMode`; rate estimation per protected attribute; Bayesian mode yields Beta-Binomial posteriors with credible intervals; schema migrates `ConfidenceInterval` → `AttributeBiasRate` with optional `ci_low`/`ci_high`
- **Agentic**: adds `statistical_mode` param; Bayesian mode propagates Beta posterior over `p` through `pass@K`/`pass^K` formula yielding credible intervals; schema adds `pass_at_k_ci_low/high` and `pass_pow_k_ci_low/high`

### Conversational, Context & Regulatory (BREAKING)

These metrics now emit **one metric per session** instead of one per QA interaction.

- **ConversationalMetric**: removed `qa_id`, `conversational_insight`, `conversational_thinkings`; each dimension is now a `ConversationalScore` (mean + optional `ci_low`/`ci_high`); adds `interactions` list
- **ContextMetric**: removed `qa_id`, `context_insight`, `context_thinkings`; `context_awareness` is now a float mean with optional CI fields; adds `interactions` list
- **RegulatoryMetric**: removed per-QA fields (`qa_id`, `query`, `assistant`, `supporting_chunks`, etc.); replaced with session-level fields and embedded `interactions` list; `verdict` is now always derived from `compliance_score`

### Core

- `Batch.weight` field for per-interaction weighting
- `FairForge._resolve_weights`: handles none/some/all weight cases
- `FairForge._aggregate_scores`: frequentist weighted mean or Bayesian bootstrap CI, shared by all three session-level metrics
- New models: `ConversationalInteraction`, `ContextInteraction`, `RegulatoryInteraction`

### Docs

Updated pages: conversational, context, regulatory, bias, agentic, dataset-batch, statistical-modes.

## Breaking Changes

- `ConversationalMetric`, `ContextMetric`, and `RegulatoryMetric` output shape changed — consumers must migrate to the new session-level schema with embedded `interactions`
- Removed fields: `qa_id`, per-QA insight/thinking fields, and individual chunk fields from `RegulatoryMetric`
