### PR TITLE
feat(prompt-optimizer): add GEPA and MIPROv2 prompt optimization module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ examples/pipeline/.virtual_documents/
 # Generated files from notebooks
 examples/**/topic.md
 examples/**/*.json
+!examples/**/data/*.json
 
 # IDEs
 .vscode/

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,6 +95,15 @@
             ]
           },
           {
+            "group": "Prompt Optimizer",
+            "icon": "wand-magic-sparkles",
+            "pages": [
+              "prompt-optimizer/overview",
+              "prompt-optimizer/gepa",
+              "prompt-optimizer/miprov2"
+            ]
+          },
+          {
             "group": "Explainability",
             "icon": "lightbulb",
             "pages": [

--- a/docs/prompt-optimizer/gepa.mdx
+++ b/docs/prompt-optimizer/gepa.mdx
@@ -1,0 +1,228 @@
+---
+title: GEPA
+description: Iteratively improve system prompts by learning from failures
+---
+
+# GEPA
+
+**GEPA (Generative Evolutionary Prompt Adaptation)** evaluates a seed prompt against your dataset, identifies the examples that fail, and generates improved candidates that address those failures. It repeats until the score stops improving or the iteration budget is exhausted.
+
+## How it works
+
+```
+Evaluate seed prompt → find failing examples
+    ↓
+Generate N improved candidates (LLM reads the failures)
+    ↓
+Evaluate each candidate → pick the best
+    ↓
+Repeat until no failures or no improvement
+```
+
+## Installation
+
+```bash
+uv add "alquimia-fair-forge"
+uv add langchain-groq  # or your preferred LLM provider
+```
+
+## Basic Usage
+
+```python
+import json
+from fair_forge import Retriever
+from fair_forge.schemas import Dataset
+from fair_forge.prompt_optimizer.gepa import GEPAOptimizer
+from langchain_groq import ChatGroq
+
+class SupportRetriever(Retriever):
+    def load_dataset(self) -> list[Dataset]:
+        with open("dataset.json", encoding="utf-8") as f:
+            return [Dataset.model_validate(item) for item in json.load(f)]
+
+model = ChatGroq(model="llama-3.3-70b-versatile")
+
+result = GEPAOptimizer.run(
+    retriever=SupportRetriever,
+    model=model,
+    seed_prompt="Eres un asistente de soporte.",
+    objective=(
+        "Responder preguntas de soporte usando únicamente el contexto proporcionado. "
+        "Las respuestas deben ser directas y concisas. "
+        "No agregar información que no esté en el contexto."
+    ),
+)
+
+print(f"Score: {result.initial_score:.2f} → {result.final_score:.2f}  ({result.n_examples} examples)")
+print(result.optimized_prompt)
+```
+
+## Parameters
+
+### Required
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `retriever` | `Type[Retriever]` | Data source class returning `list[Dataset]` |
+| `model` | `BaseChatModel` | LangChain-compatible model used for candidate generation |
+| `seed_prompt` | `str` | Current system prompt to improve |
+| `objective` | `str` | Plain language description of what a good response looks like |
+
+### Optional
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `executor` | `Callable` | Default executor | Function that calls your agent: `(prompt, query, context) → str` |
+| `evaluator` | `Callable` | `LLMEvaluator` | Function that scores a response: `(actual, expected, query, context) → float` |
+| `iterations` | `int` | `5` | Maximum number of improvement iterations |
+| `candidates_per_iteration` | `int` | `3` | Candidate prompts generated per iteration |
+| `failure_threshold` | `float` | `0.6` | Score below which an example is considered failing |
+
+## Custom Executor
+
+By default, GEPA calls the `model` directly with the candidate prompt. If your agent is more complex (has memory, tools, an API), pass a custom executor:
+
+```python
+def my_executor(prompt: str, query: str, context: str) -> str:
+    return my_agent.call(system=prompt, user=query, context=context)
+
+result = GEPAOptimizer.run(
+    retriever=MyRetriever,
+    model=model,
+    seed_prompt="...",
+    objective="...",
+    executor=my_executor,
+)
+```
+
+## Custom Evaluator
+
+For structured or deterministic tasks, a custom evaluator gives sharper signal than the LLM judge:
+
+```python
+import json, re
+
+def json_evaluator(actual: str, expected: str, query: str, context: str) -> float:
+    try:
+        parsed = json.loads(actual)
+        expected_dict = json.loads(expected)
+    except json.JSONDecodeError:
+        return 0.0
+    # Score based on field presence and value correctness
+    fields_ok = all(k in parsed for k in expected_dict)
+    values_ok = parsed == expected_dict
+    return (int(fields_ok) + int(values_ok)) / 2.0
+
+result = GEPAOptimizer.run(
+    retriever=MyRetriever,
+    model=model,
+    seed_prompt="...",
+    objective="...",
+    evaluator=json_evaluator,
+)
+```
+
+<Note>
+  Use a custom evaluator when the task has deterministic success criteria (valid JSON, specific fields, exact format). Use the default `LLMEvaluator` when quality is subjective (tone, clarity, factual grounding).
+</Note>
+
+## Output Schema
+
+### OptimizationResult
+
+```python
+result.optimized_prompt   # str   — best prompt found
+result.initial_score      # float — seed prompt score (0.0–1.0)
+result.final_score        # float — best score achieved (0.0–1.0)
+result.iterations_run     # int   — how many iterations were executed
+result.n_examples         # int   — total examples evaluated
+result.history            # list[IterationResult]
+```
+
+### IterationResult
+
+```python
+for iteration in result.history:
+    print(f"Iteration {iteration.iteration} — best: {iteration.best_score:.2f}")
+    for candidate in iteration.candidates:
+        marker = " ✓" if candidate.prompt == iteration.best_prompt else ""
+        print(f"  [{candidate.score:.2f}]{marker} {candidate.prompt}")
+```
+
+### Score interpretation
+
+The score is the average across all examples of what the evaluator returns (0.0–1.0). With the default `LLMEvaluator`, it represents how well the agent follows the `objective` criteria as judged by the LLM.
+
+| Score | Interpretation |
+|-------|----------------|
+| 0.8–1.0 | Excellent — agent consistently meets the objective |
+| 0.6–0.8 | Good — minor deviations |
+| 0.4–0.6 | Moderate — frequent misses |
+| 0.0–0.4 | Poor — prompt is clearly inadequate |
+
+## LLM Provider Options
+
+<CodeGroup>
+```python Groq
+from langchain_groq import ChatGroq
+model = ChatGroq(model="llama-3.3-70b-versatile", api_key="your-api-key")
+```
+
+```python OpenAI
+from langchain_openai import ChatOpenAI
+model = ChatOpenAI(model="gpt-4o", api_key="your-api-key")
+```
+
+```python Anthropic
+from langchain_anthropic import ChatAnthropic
+model = ChatAnthropic(model="claude-sonnet-4-6", api_key="your-api-key")
+```
+
+```python Ollama (Local)
+from langchain_ollama import ChatOllama
+model = ChatOllama(model="llama3.1:70b")
+```
+</CodeGroup>
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Write a specific objective">
+    Vague objectives produce vague improvements. Be explicit about what the agent should and should not do:
+
+    ```python
+    # Too vague
+    objective = "Be a good assistant."
+
+    # Better
+    objective = (
+        "Answer support questions using only the information in the provided context. "
+        "Be concise and direct. Do not add information not present in the context. "
+        "Do not invent prices, steps, or features."
+    )
+    ```
+  </Accordion>
+
+  <Accordion title="Start with a deliberately bad seed prompt">
+    A seed prompt like `"Eres un asistente."` gives GEPA maximum room to improve and produces a more dramatic demonstration of the optimization. If your current prompt is already decent, the improvement will be smaller.
+  </Accordion>
+
+  <Accordion title="Use a deterministic evaluator for structured tasks">
+    If the expected output follows a strict format (JSON, numbered steps, specific fields), write a deterministic evaluator. It gives GEPA a much clearer signal than an LLM judge on whether a candidate is correct.
+  </Accordion>
+
+  <Accordion title="Dataset size">
+    8–20 examples is enough for GEPA. Too few examples and the signal is noisy; too many and each iteration becomes slow. If you have many examples, consider sampling a representative subset.
+  </Accordion>
+</AccordionGroup>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="MIPROv2" icon="sparkles" href="/prompt-optimizer/miprov2">
+    Optimize instruction AND few-shot examples simultaneously
+  </Card>
+  <Card title="Retriever" icon="database" href="/core-concepts/retriever">
+    Build a Retriever to load your evaluation dataset
+  </Card>
+</CardGroup>

--- a/docs/prompt-optimizer/miprov2.mdx
+++ b/docs/prompt-optimizer/miprov2.mdx
@@ -1,0 +1,224 @@
+---
+title: MIPROv2
+description: Optimize instruction and few-shot examples together using Bayesian search
+---
+
+# MIPROv2
+
+**MIPROv2 (Multiprompt Instruction PRoposal Optimizer v2)** optimizes two things simultaneously: the system prompt instruction and the few-shot examples embedded in it. It uses Bayesian Optimization (Optuna/TPE) to efficiently search through combinations without testing all of them.
+
+## How it works
+
+**Phase 1 — Proposal**
+
+- `InstructionProposer` generates N instruction variants from the seed prompt, each emphasizing a different aspect (conciseness, format, grounding, tone, etc.)
+- `DemoBootstrapper` creates M sets of few-shot examples by sampling from the dataset
+
+**Phase 2 — Bayesian Search**
+
+- Each trial picks a combination: `(instruction_i, demo_set_j)`
+- Evaluates it on a minibatch of the dataset
+- Optuna/TPE models which combinations are most promising and prioritizes those
+
+**Output**: the best `(instruction, demo_set)` pair assembled into a ready-to-use system prompt.
+
+## When to use MIPROv2 over GEPA
+
+MIPROv2 shines when **format and style** matter as much as content — situations where seeing worked examples teaches the model what to do better than instructions alone. A technical troubleshooting bot that must follow a 4-section structure, a support bot that must respond step-by-step, or a classification agent that must match a specific output format.
+
+## Installation
+
+```bash
+uv add "alquimia-fair-forge"
+uv add langchain-groq  # or your preferred LLM provider
+```
+
+## Basic Usage
+
+```python
+import json
+from fair_forge import Retriever
+from fair_forge.schemas import Dataset
+from fair_forge.prompt_optimizer.mipro import MIPROv2Optimizer
+from langchain_groq import ChatGroq
+
+class IncidentsRetriever(Retriever):
+    def load_dataset(self) -> list[Dataset]:
+        with open("dataset.json", encoding="utf-8") as f:
+            return [Dataset.model_validate(item) for item in json.load(f)]
+
+model = ChatGroq(model="llama-3.3-70b-versatile")
+
+result = MIPROv2Optimizer.run(
+    retriever=IncidentsRetriever,
+    model=model,
+    seed_prompt="Eres un agente de soporte técnico.",
+    objective=(
+        "Responder incidencias técnicas con un diagnóstico estructurado en 4 secciones: "
+        "Diagnóstico, Causa probable, Solución inmediata (pasos numerados), y Seguimiento. "
+        "Usar únicamente la información del contexto proporcionado."
+    ),
+)
+
+print(f"Score: {result.initial_score:.2f} → {result.final_score:.2f}  ({result.n_examples} examples)")
+print(result.optimized_prompt)
+```
+
+## Parameters
+
+### Required
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `retriever` | `Type[Retriever]` | Data source class returning `list[Dataset]` |
+| `model` | `BaseChatModel` | LangChain-compatible model for instruction generation and evaluation |
+| `seed_prompt` | `str` | Current system prompt to improve |
+| `objective` | `str` | Plain language description of what a good response looks like |
+
+### Optional
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `executor` | `Callable` | Default executor | Function that calls your agent: `(prompt, query, context) → str` |
+| `evaluator` | `Callable` | `LLMEvaluator` | Function that scores a response: `(actual, expected, query, context) → float` |
+| `num_candidates` | `int` | `10` | Instruction variants to generate in Phase 1 |
+| `num_trials` | `int` | `20` | Bayesian optimization trials (combinations to evaluate) |
+| `minibatch_size` | `int` | `25` | Examples per trial (uses full dataset if smaller) |
+| `max_demos_per_set` | `int` | `3` | Maximum few-shot examples per demo set |
+| `num_demo_sets` | `int` | `5` | Demo set variants to generate in Phase 1 |
+| `random_seed` | `int` | `42` | Seed for reproducibility |
+
+## Output Schema
+
+### MIPROv2Result
+
+```python
+result.optimized_prompt        # str         — instruction + examples, ready to use as system prompt
+result.optimized_instruction   # str         — instruction part only (without examples)
+result.initial_score           # float       — seed prompt score (0.0–1.0)
+result.final_score             # float       — best score found (0.0–1.0)
+result.trials_run              # int         — number of trials executed
+result.n_examples              # int         — total examples in the dataset
+result.demos                   # list[Demo]  — selected few-shot examples
+result.trials                  # list[TrialResult]
+```
+
+### Inspecting results
+
+```python
+# Trial history — see how the search progressed
+best_so_far = 0.0
+for t in result.trials:
+    is_best = t.score > best_so_far
+    if is_best:
+        best_so_far = t.score
+    marker = " ★ new best" if is_best else ""
+    print(f"  Trial {t.trial + 1:2d} — instruction #{t.instruction_idx + 1}, "
+          f"demo set #{t.demo_set_idx + 1} — score: {t.score:.2f}{marker}")
+
+# Final result — instruction and examples separately
+print("=== Optimized instruction ===")
+print(result.optimized_instruction)
+
+print("=== Selected examples ===")
+for demo in result.demos:
+    print(f"User: {demo.query}")
+    print(f"Assistant: {demo.response}")
+    print()
+```
+
+### Score interpretation
+
+| Score | Interpretation |
+|-------|----------------|
+| 0.8–1.0 | Excellent — agent consistently meets the objective |
+| 0.6–0.8 | Good — minor deviations |
+| 0.4–0.6 | Moderate — frequent misses |
+| 0.0–0.4 | Poor — prompt is clearly inadequate |
+
+<Note>
+  The score is the average across all examples of what the evaluator returns (0.0–1.0). With the default `LLMEvaluator`, it represents how well the agent follows the `objective` as judged by the LLM.
+</Note>
+
+## Custom Executor
+
+If your agent is more than a direct model call (has memory, tools, an API), pass a custom executor:
+
+```python
+def my_executor(prompt: str, query: str, context: str) -> str:
+    return my_agent.call(system=prompt, user=query, context=context)
+
+result = MIPROv2Optimizer.run(
+    retriever=MyRetriever,
+    model=model,
+    seed_prompt="...",
+    objective="...",
+    executor=my_executor,
+)
+```
+
+## LLM Provider Options
+
+<CodeGroup>
+```python Groq
+from langchain_groq import ChatGroq
+model = ChatGroq(model="llama-3.3-70b-versatile", api_key="your-api-key")
+```
+
+```python OpenAI
+from langchain_openai import ChatOpenAI
+model = ChatOpenAI(model="gpt-4o", api_key="your-api-key")
+```
+
+```python Anthropic
+from langchain_anthropic import ChatAnthropic
+model = ChatAnthropic(model="claude-sonnet-4-6", api_key="your-api-key")
+```
+
+```python Ollama (Local)
+from langchain_ollama import ChatOllama
+model = ChatOllama(model="llama3.1:70b")
+```
+</CodeGroup>
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Choose tasks where examples matter">
+    MIPROv2 is most valuable when the expected output follows a specific format or style that's hard to fully specify in instructions. A structured diagnosis template, a numbered step-by-step response, or a classification with a fixed schema are ideal cases.
+  </Accordion>
+
+  <Accordion title="Write a specific objective">
+    The `objective` drives both instruction generation and LLM-based evaluation. Include the output format you expect:
+
+    ```python
+    objective = (
+        "Respond to technical incidents with a structured diagnosis in exactly 4 sections: "
+        "1) Diagnosis: what is happening in one line. "
+        "2) Probable cause: why it occurs in one line. "
+        "3) Immediate solution: numbered steps to fix the issue. "
+        "4) Follow-up: next steps or prevention in one line. "
+        "Use only information from the provided context."
+    )
+    ```
+  </Accordion>
+
+  <Accordion title="Ground truth is the few-shot source">
+    MIPROv2 builds demo sets from your `ground_truth_assistant` field. The quality of your ground truth directly determines the quality of the few-shot examples the optimizer can select. Write ideal responses in your dataset.
+  </Accordion>
+
+  <Accordion title="Tune num_trials vs speed">
+    More trials means better coverage of the search space but slower execution. With `num_candidates=10` and `num_demo_sets=5` there are 50 possible combinations. `num_trials=20` covers 40% of the space guided by Bayesian search, which is usually enough.
+  </Accordion>
+</AccordionGroup>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="GEPA" icon="arrow-trend-up" href="/prompt-optimizer/gepa">
+    Iterative prompt improvement from failures
+  </Card>
+  <Card title="Retriever" icon="database" href="/core-concepts/retriever">
+    Build a Retriever to load your evaluation dataset
+  </Card>
+</CardGroup>

--- a/docs/prompt-optimizer/miprov2.mdx
+++ b/docs/prompt-optimizer/miprov2.mdx
@@ -87,6 +87,9 @@ print(result.optimized_prompt)
 | `max_demos_per_set` | `int` | `3` | Maximum few-shot examples per demo set |
 | `num_demo_sets` | `int` | `5` | Demo set variants to generate in Phase 1 |
 | `random_seed` | `int` | `42` | Seed for reproducibility |
+| `tips` | `list[str]` | Built-in list | Focus areas used to guide instruction generation (e.g. "Be concise", "Specify output format") |
+| `instruction_proposal_system` | `str` | Built-in prompt | System prompt used when calling the LLM to generate instruction candidates |
+| `instruction_proposal_user` | `str` | Built-in prompt | User prompt template for instruction generation (must contain `{seed_prompt}`, `{objective}`, `{n}`, `{tips}`) |
 
 ## Output Schema
 

--- a/docs/prompt-optimizer/overview.mdx
+++ b/docs/prompt-optimizer/overview.mdx
@@ -1,0 +1,99 @@
+---
+title: Prompt Optimizer
+description: Automatically improve AI agent system prompts using GEPA and MIPROv2
+---
+
+# Prompt Optimizer
+
+The Prompt Optimizer module closes the evaluation loop: once Fair Forge measures where your agent fails, these tools automatically find the system prompt that fixes those failures.
+
+## How it fits into Fair Forge
+
+```
+Fair Forge measures metrics (Context, Conversational, etc.)
+    ↓ failing examples become your dataset
+GEPAOptimizer or MIPROv2Optimizer finds the best prompt
+    ↓ optimized prompt deployed to your agent
+Fair Forge measures again to confirm improvement
+```
+
+## Available Optimizers
+
+<CardGroup cols={2}>
+  <Card title="GEPA" icon="arrow-trend-up" href="/prompt-optimizer/gepa">
+    Iteratively reads failures and generates improved prompt candidates. Best when the prompt itself is clearly wrong.
+  </Card>
+  <Card title="MIPROv2" icon="sparkles" href="/prompt-optimizer/miprov2">
+    Optimizes instruction AND few-shot examples simultaneously using Bayesian search. Best when format and tone matter as much as content.
+  </Card>
+</CardGroup>
+
+## When to use each
+
+| | GEPA | MIPROv2 |
+|---|---|---|
+| **Optimizes** | Prompt instruction | Instruction + few-shot examples |
+| **Search strategy** | Iterative, reads failures | Bayesian (Optuna/TPE) |
+| **Best for** | Clearly bad prompts | Format-sensitive tasks |
+| **Speed** | Fast (few iterations) | Slower (20+ trials) |
+| **Examples needed** | No | Yes — key differentiator |
+
+## Installation
+
+```bash
+uv add "alquimia-fair-forge"
+uv add langchain-groq  # or your preferred LLM provider
+```
+
+## Common Pattern
+
+Both optimizers follow the same Fair Forge pattern:
+
+```python
+from fair_forge import Retriever
+from fair_forge.schemas import Dataset
+
+class MyRetriever(Retriever):
+    def load_dataset(self) -> list[Dataset]:
+        # Return your evaluation dataset
+        ...
+
+result = AnyOptimizer.run(
+    retriever=MyRetriever,
+    model=model,
+    seed_prompt="Your current (bad) system prompt.",
+    objective="Plain language description of what a good response looks like.",
+)
+
+print(result.optimized_prompt)
+```
+
+<Note>
+  The `objective` is the most important parameter. Describe what a **good** response looks like — the optimizer uses it to evaluate candidates and guide generation.
+</Note>
+
+## Custom Evaluator
+
+By default both optimizers use an LLM judge based on the `objective`. For structured or deterministic tasks, pass a custom evaluator for sharper signal:
+
+```python
+from fair_forge.prompt_optimizer import LLMEvaluator
+
+# Default — describe criteria in natural language
+evaluator = LLMEvaluator(
+    model=model,
+    criteria="Response must use only the provided context and be concise.",
+)
+
+# Custom — deterministic logic
+def my_evaluator(actual: str, expected: str, query: str, context: str) -> float:
+    # Return a float between 0.0 and 1.0
+    ...
+```
+
+## Output
+
+```python
+print(f"Score: {result.initial_score:.2f} → {result.final_score:.2f}  ({result.n_examples} examples)")
+print(result.optimized_prompt)
+```

--- a/examples/prompt_optimizer/gepa/data/dataset.json
+++ b/examples/prompt_optimizer/gepa/data/dataset.json
@@ -1,0 +1,90 @@
+[
+  {
+    "session_id": "support-billing",
+    "assistant_id": "support-bot",
+    "language": "spanish",
+    "context": "Nexo ofrece tres planes: Free (hasta 3 proyectos, 5 miembros, sin soporte prioritario), Pro ($15/mes por usuario, proyectos ilimitados, soporte prioritario, 50 GB de almacenamiento) y Business ($25/mes por usuario, todo lo de Pro más auditoría de acceso, SSO y soporte 24/7). Los pagos se procesan el primer día de cada mes. Para actualizar tu plan, ve a Configuración > Facturación > Cambiar plan. Los cambios son inmediatos. Para cancelar, ve a Configuración > Facturación > Cancelar suscripción — tu plan activo continúa hasta el fin del período facturado.",
+    "conversation": [
+      {
+        "qa_id": "billing-001",
+        "query": "¿Cuánto cuesta el plan Pro y qué incluye?",
+        "ground_truth_assistant": "El plan Pro cuesta $15 por usuario por mes. Incluye proyectos ilimitados, soporte prioritario y 50 GB de almacenamiento.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      },
+      {
+        "qa_id": "billing-002",
+        "query": "Si cancelo hoy, ¿pierdo el acceso inmediatamente?",
+        "ground_truth_assistant": "No. Al cancelar, tu plan activo continúa hasta el fin del período facturado actual.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      }
+    ]
+  },
+  {
+    "session_id": "support-auth",
+    "assistant_id": "support-bot",
+    "language": "spanish",
+    "context": "Para recuperar tu contraseña, ve a la pantalla de inicio de sesión y hacé clic en '¿Olvidaste tu contraseña?'. Ingresá tu email y recibirás un enlace de recuperación válido por 30 minutos. Si no recibís el email, revisá la carpeta de spam o verificá que la dirección esté registrada en Nexo. La verificación en dos pasos (2FA) se activa desde Configuración > Seguridad > Verificación en dos pasos. Nexo es compatible con Google Authenticator y Authy. Una vez activado, el 2FA es obligatorio para todos los inicios de sesión desde dispositivos nuevos.",
+    "conversation": [
+      {
+        "qa_id": "auth-001",
+        "query": "Pedí el email de recuperación de contraseña y no me llegó nada.",
+        "ground_truth_assistant": "Revisá tu carpeta de spam. Si no está ahí, verificá que el email que ingresaste esté registrado en Nexo. El enlace de recuperación es válido por 30 minutos.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      },
+      {
+        "qa_id": "auth-002",
+        "query": "¿Cómo activo la verificación en dos pasos?",
+        "ground_truth_assistant": "Andá a Configuración > Seguridad > Verificación en dos pasos. Nexo es compatible con Google Authenticator y Authy. Una vez activado, se pedirá en cada inicio de sesión desde un dispositivo nuevo.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      }
+    ]
+  },
+  {
+    "session_id": "support-storage",
+    "assistant_id": "support-bot",
+    "language": "spanish",
+    "context": "Nexo permite adjuntar archivos a tareas y proyectos. Los formatos soportados son: imágenes (JPG, PNG, GIF, WebP), documentos (PDF, DOCX, XLSX, PPTX, TXT), y archivos comprimidos (ZIP, RAR). El tamaño máximo por archivo es de 100 MB en el plan Pro y 250 MB en el plan Business. El plan Free tiene un límite de 10 MB por archivo. Los videos no están soportados como adjuntos — para compartir videos, usá un enlace externo (YouTube, Vimeo, Drive). El almacenamiento total del plan Pro es de 50 GB y del plan Business ilimitado.",
+    "conversation": [
+      {
+        "qa_id": "storage-001",
+        "query": "Intenté subir un archivo de 120 MB y me dio error. Tengo el plan Pro.",
+        "ground_truth_assistant": "El límite por archivo en el plan Pro es de 100 MB. Tu archivo de 120 MB supera ese límite. Para archivos más grandes necesitás el plan Business, que permite hasta 250 MB por archivo.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      },
+      {
+        "qa_id": "storage-002",
+        "query": "¿Puedo adjuntar videos a una tarea?",
+        "ground_truth_assistant": "No, los videos no están soportados como adjuntos. Para compartir un video, usá un enlace externo de YouTube, Vimeo o Drive.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      }
+    ]
+  },
+  {
+    "session_id": "support-permissions",
+    "assistant_id": "support-bot",
+    "language": "spanish",
+    "context": "Nexo tiene tres roles de equipo: Admin, Member y Viewer. El Admin puede agregar y eliminar miembros, cambiar roles, crear y eliminar proyectos, y modificar la configuración del espacio de trabajo. El Member puede crear y editar tareas, comentar, y ver todos los proyectos a los que tiene acceso. El Viewer solo puede ver tareas y comentarios, sin poder editarlos ni crear nuevos. Para cambiar el rol de un miembro, el Admin debe ir a Configuración > Equipo, seleccionar al miembro y elegir el nuevo rol. Los cambios de rol son efectivos de inmediato.",
+    "conversation": [
+      {
+        "qa_id": "permissions-001",
+        "query": "¿Un Viewer puede crear tareas?",
+        "ground_truth_assistant": "No. El rol Viewer solo permite ver tareas y comentarios, sin poder editarlos ni crear nuevos.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      },
+      {
+        "qa_id": "permissions-002",
+        "query": "¿Cómo le cambio el rol a un miembro del equipo?",
+        "ground_truth_assistant": "Andá a Configuración > Equipo, seleccioná al miembro y elegí el nuevo rol. Solo los Admins pueden cambiar roles y el cambio es inmediato.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      }
+    ]
+  }
+]

--- a/examples/prompt_optimizer/gepa/jupyter/gepa.ipynb
+++ b/examples/prompt_optimizer/gepa/jupyter/gepa.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# GEPA Prompt Optimizer — Bot de soporte al cliente\n",
+    "\n",
+    "**Caso de uso:** un bot de soporte recibe preguntas de usuarios junto con un fragmento de la base de conocimiento (contexto). Con el seed prompt `\"Eres un asistente de soporte.\"`, el bot ignora el contexto y responde con información genérica o inventada. GEPA optimiza el prompt para que el bot use únicamente el contexto, sea conciso y no alucine.\n",
+    "\n",
+    "El dataset contiene 4 temas de soporte (facturación, acceso, almacenamiento, permisos) con 2 preguntas cada uno. Cada `Dataset` tiene su propio `context` — el fragmento de FAQ relevante para esas preguntas.\n",
+    "\n",
+    "**Sin evaluador custom.** GEPA usa el `LLMEvaluator` interno con el `objective` como criterio."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-1",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\nimport logging\nimport getpass\n\nlogging.getLogger(\"httpx\").setLevel(logging.WARNING)\n\nif not os.environ.get(\"GROQ_API_KEY\"):\n    os.environ[\"GROQ_API_KEY\"] = getpass.getpass(\"Enter your Groq API key: \")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, str(Path().resolve().parents[3]))\n",
+    "sys.path.insert(0, str(Path().resolve().parents[3] / \"examples\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-4",
+   "metadata": {},
+   "source": [
+    "## 1. Retriever\n",
+    "\n",
+    "Carga las preguntas de soporte y sus respuestas esperadas. Cada `Dataset` incluye el fragmento de FAQ relevante en `context` — el mismo que se inyecta al agente en cada consulta."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": "import json\nfrom pathlib import Path\nfrom fair_forge import Retriever\nfrom fair_forge.schemas import Dataset\n\nclass SupportRetriever(Retriever):\n    def load_dataset(self) -> list[Dataset]:\n        data_path = Path(\"../data/dataset.json\")\n        with open(data_path, encoding=\"utf-8\") as f:\n            return [Dataset.model_validate(item) for item in json.load(f)]"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-6",
+   "metadata": {},
+   "source": [
+    "## 2. Model\n",
+    "\n",
+    "El modelo que GEPA usa para **generar prompts candidatos mejorados**. No es el agente que se está optimizando — ese usa el mismo modelo con el prompt candidato como system prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_groq import ChatGroq\n",
+    "\n",
+    "model = ChatGroq(model=\"llama-3.3-70b-versatile\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-8",
+   "metadata": {},
+   "source": [
+    "## 3. Run the optimizer\n",
+    "\n",
+    "- `seed_prompt`: el prompt actual del agente — deliberadamente vago.\n",
+    "- `objective`: describe en lenguaje natural qué hace un buen agente de soporte. GEPA lo usa para evaluar respuestas y guiar la generación de mejores prompts.\n",
+    "- Sin `evaluator` explícito: GEPA usa un juez LLM interno basado en el `objective`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cell-9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-11 11:29:05,152 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:05,435 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:06,436 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:06,769 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:07,951 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:08,247 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:09,315 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:09,612 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:10,836 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:11,221 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:11,816 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:12,095 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:12,502 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:12,788 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:14,077 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:14,484 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:15,438 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:15,850 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:16,126 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:16,689 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:16,967 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:17,602 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:18,044 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:18,677 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:18,994 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:19,573 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:19,970 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:20,491 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:20,763 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:21,113 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:21,386 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:22,033 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:22,505 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:23,055 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:23,546 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:24,038 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:24,314 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:25,888 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:26,360 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:27,489 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:28,038 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:29,664 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:30,021 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:30,602 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:30,994 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:31,588 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:31,970 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:34,088 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:34,602 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:35,283 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:35,659 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:36,436 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:36,836 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:37,985 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:38,370 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:39,353 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:39,833 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:41,263 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:41,712 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:42,202 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:42,496 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:42,915 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:43,205 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:44,548 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2026-03-11 11:29:44,952 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fair_forge.prompt_optimizer.gepa import GEPAOptimizer\n",
+    "\n",
+    "result = GEPAOptimizer.run(\n",
+    "    retriever=SupportRetriever,\n",
+    "    model=model,\n",
+    "    seed_prompt=\"Eres un asistente de soporte.\",\n",
+    "    objective=(\n",
+    "        \"Responder preguntas de soporte usando únicamente la información del contexto proporcionado. \"\n",
+    "        \"Las respuestas deben ser directas y concisas. \"\n",
+    "        \"No agregar información que no esté en el contexto. No inventar datos, precios, pasos ni funcionalidades.\"\n",
+    "    ),\n",
+    "    iterations=5,\n",
+    "    candidates_per_iteration=3,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "## 4. Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-12",
+   "metadata": {},
+   "outputs": [],
+   "source": "print(f\"Initial score : {result.initial_score:.2f} / 1.00  (LLM judge · {result.n_examples} examples)\")\nprint(f\"Final score   : {result.final_score:.2f} / 1.00  (LLM judge · {result.n_examples} examples)\")\nprint(f\"Iterations run: {result.iterations_run}\")\nprint()\nprint(\"=== Seed prompt ===\")\nprint(\"Eres un asistente de soporte.\")\nprint()\nprint(\"=== Optimized prompt ===\")\nprint(result.optimized_prompt)"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/prompt_optimizer/mipro/data/dataset.json
+++ b/examples/prompt_optimizer/mipro/data/dataset.json
@@ -1,0 +1,90 @@
+[
+  {
+    "session_id": "incidents-notifications",
+    "assistant_id": "support-bot",
+    "language": "spanish",
+    "context": "El sistema de notificaciones de Nexo soporta tres canales: email, Slack y notificaciones in-app. Las notificaciones de Slack requieren que la integración esté activa en Configuración > Integraciones y que el canal destino esté correctamente configurado. Un error común es que el bot de Nexo no tenga permisos de escritura en el canal seleccionado. Para verificarlo: Slack > Manage Apps > Nexo > Permissions. Las notificaciones en exceso se gestionan desde Configuración > Notificaciones > Frecuencia, donde se puede activar el modo 'Resumen diario' para agruparlas.",
+    "conversation": [
+      {
+        "qa_id": "notif-001",
+        "query": "No recibo notificaciones de Nexo en Slack aunque tengo la integración activada.",
+        "ground_truth_assistant": "**Diagnóstico:** La integración de Slack está activa pero las notificaciones no llegan al canal configurado.\n\n**Causa probable:** El bot de Nexo no tiene permisos de escritura en el canal destino.\n\n**Solución inmediata:**\n1. Abrí Slack > Manage Apps > Nexo > Permissions.\n2. Verificá que el canal destino figure en la lista de canales permitidos.\n3. Si no está, agregalo y guardá los cambios.\n4. Enviá una notificación de prueba desde Configuración > Integraciones > Slack > Probar.\n\n**Seguimiento:** Si el problema persiste, desconectá y reconectá la integración desde Configuración > Integraciones.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      },
+      {
+        "qa_id": "notif-002",
+        "query": "Recibo demasiadas notificaciones y no puedo encontrar cómo reducirlas.",
+        "ground_truth_assistant": "**Diagnóstico:** El volumen de notificaciones supera lo esperado y la configuración actual no las agrupa.\n\n**Causa probable:** El modo de frecuencia está configurado en 'Inmediata' en lugar de 'Resumen diario'.\n\n**Solución inmediata:**\n1. Andá a Configuración > Notificaciones > Frecuencia.\n2. Cambiá el modo a 'Resumen diario' para agrupar todas las notificaciones en un solo email o mensaje.\n3. Guardá los cambios.\n\n**Seguimiento:** Podés personalizar qué tipos de eventos generan notificaciones desde la misma sección.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      }
+    ]
+  },
+  {
+    "session_id": "incidents-performance",
+    "assistant_id": "support-bot",
+    "language": "spanish",
+    "context": "La vista de cronograma de Nexo carga todos los datos del proyecto en memoria del cliente. Para proyectos con más de 500 tareas, el tiempo de carga puede superar los 20 segundos en conexiones lentas. La solución recomendada es activar la paginación desde Configuración del proyecto > Vista > Paginación de cronograma (disponible en planes Pro y Business). Las búsquedas globales usan un índice que se actualiza cada 5 minutos, por lo que cambios recientes pueden no aparecer de inmediato.",
+    "conversation": [
+      {
+        "qa_id": "perf-001",
+        "query": "La vista de cronograma tarda más de 30 segundos en cargar. El proyecto tiene 800 tareas.",
+        "ground_truth_assistant": "**Diagnóstico:** La vista de cronograma está cargando las 800 tareas completas en memoria, lo que supera el umbral de rendimiento recomendado.\n\n**Causa probable:** La paginación de cronograma no está activada, forzando la carga completa de todos los datos.\n\n**Solución inmediata:**\n1. Andá a Configuración del proyecto > Vista > Paginación de cronograma.\n2. Activá la opción y configurá el tamaño de página (recomendado: 100 tareas).\n3. Guardá y recargá la vista.\n\n**Seguimiento:** Esta función está disponible en planes Pro y Business. Si estás en plan Free, considerá dividir el proyecto en subproyectos más pequeños.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      },
+      {
+        "qa_id": "perf-002",
+        "query": "Moví una tarea a 'Completado' hace 10 minutos y en la búsqueda global sigue apareciendo como pendiente.",
+        "ground_truth_assistant": "**Diagnóstico:** El estado de la tarea en la búsqueda global no refleja el cambio reciente.\n\n**Causa probable:** El índice de búsqueda global se actualiza cada 5 minutos, por lo que cambios recientes pueden tener un retraso visible.\n\n**Solución inmediata:**\n1. Esperá hasta 5 minutos y volvé a buscar.\n2. Si el problema persiste más de 10 minutos, forzá una reindexación desde Configuración > Búsqueda > Reindexar workspace.\n\n**Seguimiento:** Este comportamiento es esperado. Si necesitás resultados en tiempo real, usá los filtros de la vista de lista en lugar de la búsqueda global.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      }
+    ]
+  },
+  {
+    "session_id": "incidents-export",
+    "assistant_id": "support-bot",
+    "language": "spanish",
+    "context": "Nexo permite exportar proyectos a PDF y Excel. La exportación a PDF tiene un límite de 200 tareas por archivo — proyectos más grandes se exportan en múltiples archivos. La exportación a Excel tiene un límite de 1000 filas por hoja; si el proyecto supera ese límite, las filas restantes se escriben en hojas adicionales. Un bug conocido en la versión 2.x hace que la exportación a PDF falle silenciosamente si el proyecto contiene imágenes adjuntas con tamaño mayor a 5 MB — el archivo se genera vacío. El workaround es eliminar temporalmente los adjuntos grandes antes de exportar.",
+    "conversation": [
+      {
+        "qa_id": "export-001",
+        "query": "Exporté el proyecto a PDF pero el archivo descargado está vacío.",
+        "ground_truth_assistant": "**Diagnóstico:** La exportación a PDF se completó pero el archivo generado no contiene datos.\n\n**Causa probable:** El proyecto contiene imágenes adjuntas con tamaño mayor a 5 MB, lo que activa un bug conocido en la versión 2.x que genera el PDF vacío.\n\n**Solución inmediata:**\n1. Identificá los adjuntos del proyecto con tamaño mayor a 5 MB desde la vista de archivos.\n2. Eliminá o reemplazá esos adjuntos temporalmente.\n3. Volvé a exportar a PDF.\n4. Una vez obtenido el archivo, podés restaurar los adjuntos originales.\n\n**Seguimiento:** Este bug está registrado y será corregido en la versión 2.1. Como alternativa, usá la exportación a Excel que no tiene esta limitación.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      },
+      {
+        "qa_id": "export-002",
+        "query": "Exporté a Excel un proyecto con 2000 tareas pero el archivo solo tiene 1000 filas.",
+        "ground_truth_assistant": "**Diagnóstico:** La exportación a Excel generó solo la mitad de las tareas esperadas.\n\n**Causa probable:** Excel tiene un límite de 1000 filas por hoja. Las 1000 tareas restantes se escribieron en hojas adicionales del mismo archivo.\n\n**Solución inmediata:**\n1. Abrí el archivo Excel exportado.\n2. Verificá las pestañas inferiores — las tareas 1001 a 2000 deberían estar en 'Hoja 2'.\n\n**Seguimiento:** Si las hojas adicionales no aparecen, el archivo puede estar corrupto. En ese caso, exportá el proyecto en dos partes usando filtros de fecha.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      }
+    ]
+  },
+  {
+    "session_id": "incidents-permissions",
+    "assistant_id": "support-bot",
+    "language": "spanish",
+    "context": "Los permisos de Nexo se evalúan en tiempo real excepto el token de sesión, que almacena el rol del usuario en el momento del login. Si se cambia el rol de un usuario mientras tiene sesión activa, el cambio no se aplica hasta que cierre sesión y vuelva a ingresar. Un bug conocido en la versión 2.x hace que los proyectos con visibilidad 'Workspace' sean visibles para todos los miembros independientemente de su rol asignado al proyecto. El workaround es cambiar la visibilidad del proyecto a 'Solo miembros' desde Configuración del proyecto > Privacidad.",
+    "conversation": [
+      {
+        "qa_id": "perm-001",
+        "query": "Un usuario con rol Member puede ver un proyecto privado al que no fue asignado.",
+        "ground_truth_assistant": "**Diagnóstico:** Un usuario accede a un proyecto al que no debería tener acceso según su rol.\n\n**Causa probable:** La visibilidad del proyecto está configurada como 'Workspace', lo que permite a todos los miembros verlo independientemente de su asignación — comportamiento de un bug conocido en la versión 2.x.\n\n**Solución inmediata:**\n1. Andá a Configuración del proyecto > Privacidad.\n2. Cambiá la visibilidad de 'Workspace' a 'Solo miembros'.\n3. Guardá los cambios — el acceso se restringirá de inmediato.\n\n**Seguimiento:** Este bug está registrado y será corregido en la versión 2.1.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      },
+      {
+        "qa_id": "perm-002",
+        "query": "Cambié el rol de un usuario de Member a Viewer pero sigue pudiendo editar tareas.",
+        "ground_truth_assistant": "**Diagnóstico:** El cambio de rol no se refleja en la sesión activa del usuario.\n\n**Causa probable:** El token de sesión almacena el rol del momento del login. El nuevo rol de Viewer no se aplica hasta que el usuario cierre sesión y vuelva a ingresar.\n\n**Solución inmediata:**\n1. Pedile al usuario que cierre sesión desde el menú superior derecho > Cerrar sesión.\n2. Al volver a ingresar, el rol Viewer quedará activo y no podrá editar tareas.\n\n**Seguimiento:** Si necesitás que el cambio sea inmediato sin que el usuario cierre sesión, podés revocar su sesión manualmente desde Configuración > Equipo > [usuario] > Cerrar sesiones activas.",
+        "assistant": "",
+        "ground_truth_agentic": {}
+      }
+    ]
+  }
+]

--- a/examples/prompt_optimizer/mipro/jupyter/mipro.ipynb
+++ b/examples/prompt_optimizer/mipro/jupyter/mipro.ipynb
@@ -1,0 +1,326 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# MIPROv2 Prompt Optimizer — Diagnóstico de incidencias técnicas\n",
+    "\n",
+    "**Caso de uso:** un bot de soporte técnico recibe errores e incidencias reportadas por usuarios y debe responder con un diagnóstico estructurado de 4 secciones: **Diagnóstico**, **Causa probable**, **Solución inmediata** (pasos numerados) y **Seguimiento**.\n",
+    "\n",
+    "Con el seed prompt `\"Eres un agente de soporte técnico.\"`, el bot responde en prosa sin estructura — el LLM judge lo penaliza porque no sigue el formato esperado. MIPROv2 encuentra la combinación de instrucción + ejemplos few-shot que enseña el formato exacto.\n",
+    "\n",
+    "El dataset cubre 4 tipos de incidencias (notificaciones, rendimiento, exportaciones, permisos) con 2 casos cada uno. Cada `Dataset` tiene su propio `context` con la documentación técnica relevante.\n",
+    "\n",
+    "**Por qué MIPROv2 y no GEPA:** el formato de 4 secciones es difícil de especificar solo con instrucciones — los ejemplos few-shot lo transmiten mucho más efectivamente."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-1",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import logging\n",
+    "import getpass\n",
+    "\n",
+    "logging.getLogger(\"httpx\").setLevel(logging.WARNING)\n",
+    "\n",
+    "if not os.environ.get(\"GROQ_API_KEY\"):\n",
+    "    os.environ[\"GROQ_API_KEY\"] = getpass.getpass(\"Enter your Groq API key: \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, str(Path().resolve().parents[3]))\n",
+    "sys.path.insert(0, str(Path().resolve().parents[3] / \"examples\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-4",
+   "metadata": {},
+   "source": [
+    "## 1. Retriever\n",
+    "\n",
+    "Carga los casos de incidencias y sus diagnósticos esperados. Cada `Dataset` incluye la documentación técnica relevante en `context`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\ericf\\Desktop\\Alquimia\\fair-forge\\.venv\\Lib\\site-packages\\requests\\__init__.py:86: RequestsDependencyWarning: Unable to find acceptable character detection dependency (chardet or charset_normalizer).\n",
+      "  warnings.warn(\n",
+      "None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "from fair_forge import Retriever\n",
+    "from fair_forge.schemas import Dataset\n",
+    "\n",
+    "class IncidentsRetriever(Retriever):\n",
+    "    def load_dataset(self) -> list[Dataset]:\n",
+    "        data_path = Path(\"../data/dataset.json\")\n",
+    "        with open(data_path, encoding=\"utf-8\") as f:\n",
+    "            return [Dataset.model_validate(item) for item in json.load(f)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-6",
+   "metadata": {},
+   "source": [
+    "## 2. Model\n",
+    "\n",
+    "El modelo que MIPROv2 usa para generar variantes de instrucción. También actúa como agente bajo optimización (ejecuta cada prompt candidato contra el dataset)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_groq import ChatGroq\n",
+    "\n",
+    "model = ChatGroq(model=\"llama-3.3-70b-versatile\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-8",
+   "metadata": {},
+   "source": [
+    "## 3. Run the optimizer\n",
+    "\n",
+    "- `seed_prompt`: el prompt actual del agente — deliberadamente vago.\n",
+    "- `objective`: describe qué hace un buen bot de onboarding. MIPROv2 lo usa para generar variantes de instrucción y evaluar respuestas.\n",
+    "- `num_candidates`: cuántas variantes de instrucción generar (default: 10).\n",
+    "- `num_trials`: cuántas combinaciones `(instrucción, ejemplos)` explorar con Bayesian Optimization (default: 20)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1c1a00de2dbc488498dff12a201a8803",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Evaluating trials:   0%|          | 0/20 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from fair_forge.prompt_optimizer.mipro import MIPROv2Optimizer\n",
+    "\n",
+    "result = MIPROv2Optimizer.run(\n",
+    "    retriever=IncidentsRetriever,\n",
+    "    model=model,\n",
+    "    seed_prompt=\"Eres un agente de soporte técnico.\",\n",
+    "    objective=(\n",
+    "        \"Responder incidencias técnicas con un diagnóstico estructurado en exactamente 4 secciones: \"\n",
+    "        \"1) Diagnóstico: qué está pasando en una línea. \"\n",
+    "        \"2) Causa probable: por qué ocurre en una línea. \"\n",
+    "        \"3) Solución inmediata: pasos numerados para resolver el problema. \"\n",
+    "        \"4) Seguimiento: próximos pasos o medida de prevención en una línea. \"\n",
+    "        \"Usar únicamente la información del contexto proporcionado. No agregar secciones adicionales.\"\n",
+    "    ),\n",
+    "    num_candidates=10,\n",
+    "    num_trials=20,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "## 4. Trial history\n",
+    "\n",
+    "Cada trial explora una combinación de instrucción y set de ejemplos. Un `★` indica un nuevo mejor score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-11",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Trial  1 — instruction #4, demo set #5 — score: 0.84 ★ new best\n",
+      "  Trial  2 — instruction #8, demo set #3 — score: 0.71\n",
+      "  Trial  3 — instruction #2, demo set #1 — score: 0.88 ★ new best\n",
+      "  Trial  4 — instruction #1, demo set #5 — score: 0.86\n",
+      "  Trial  5 — instruction #7, demo set #4 — score: 0.78\n",
+      "  Trial  6 — instruction #1, demo set #5 — score: 0.89 ★ new best\n",
+      "  Trial  7 — instruction #9, demo set #2 — score: 0.81\n",
+      "  Trial  8 — instruction #2, demo set #1 — score: 0.89\n",
+      "  Trial  9 — instruction #4, demo set #3 — score: 0.87\n",
+      "  Trial 10 — instruction #5, demo set #2 — score: 0.73\n",
+      "  Trial 11 — instruction #10, demo set #4 — score: 0.79\n",
+      "  Trial 12 — instruction #2, demo set #1 — score: 0.87\n",
+      "  Trial 13 — instruction #1, demo set #4 — score: 0.89 ★ new best\n",
+      "  Trial 14 — instruction #1, demo set #4 — score: 0.92 ★ new best\n",
+      "  Trial 15 — instruction #3, demo set #4 — score: 0.88\n",
+      "  Trial 16 — instruction #6, demo set #3 — score: 0.72\n",
+      "  Trial 17 — instruction #1, demo set #4 — score: 0.93 ★ new best\n",
+      "  Trial 18 — instruction #3, demo set #4 — score: 0.85\n",
+      "  Trial 19 — instruction #5, demo set #2 — score: 0.72\n",
+      "  Trial 20 — instruction #3, demo set #3 — score: 0.86\n"
+     ]
+    }
+   ],
+   "source": [
+    "best_so_far = 0.0\n",
+    "for t in result.trials:\n",
+    "    is_best = t.score > best_so_far\n",
+    "    if is_best:\n",
+    "        best_so_far = t.score\n",
+    "    marker = \" ★ new best\" if is_best else \"\"\n",
+    "    print(f\"  Trial {t.trial + 1:2d} — instruction #{t.instruction_idx + 1}, demo set #{t.demo_set_idx + 1} — score: {t.score:.2f}{marker}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12",
+   "metadata": {},
+   "source": [
+    "## 5. Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-13",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial score : 0.23 / 1.00  (LLM judge · 8 examples)\n",
+      "Final score   : 0.93 / 1.00  (LLM judge · 8 examples)\n",
+      "Trials run    : 20\n",
+      "\n",
+      "=== Seed prompt ===\n",
+      "Eres un agente de soporte técnico.\n",
+      "\n",
+      "=== Optimized instruction ===\n",
+      "Eres un agente de soporte técnico que debe evitar proporcionar soluciones irrelevantes o información adicional no solicitada. Responde incidencias técnicas con un diagnóstico estructurado en exactamente 4 secciones: 1) Diagnóstico: qué está pasando en una línea. 2) Causa probable: por qué ocurre en una línea. 3) Solución inmediata: pasos numerados para resolver el problema. 4) Seguimiento: próximos pasos o medida de prevención en una línea.\n",
+      "\n",
+      "=== Selected examples ===\n",
+      "User: Recibo demasiadas notificaciones y no puedo encontrar cómo reducirlas.\n",
+      "Assistant: **Diagnóstico:** El volumen de notificaciones supera lo esperado y la configuración actual no las agrupa.\n",
+      "\n",
+      "**Causa probable:** El modo de frecuencia está configurado en 'Inmediata' en lugar de 'Resumen diario'.\n",
+      "\n",
+      "**Solución inmediata:**\n",
+      "1. Andá a Configuración > Notificaciones > Frecuencia.\n",
+      "2. Cambiá el modo a 'Resumen diario' para agrupar todas las notificaciones en un solo email o mensaje.\n",
+      "3. Guardá los cambios.\n",
+      "\n",
+      "**Seguimiento:** Podés personalizar qué tipos de eventos generan notificaciones desde la misma sección.\n",
+      "\n",
+      "User: Exporté el proyecto a PDF pero el archivo descargado está vacío.\n",
+      "Assistant: **Diagnóstico:** La exportación a PDF se completó pero el archivo generado no contiene datos.\n",
+      "\n",
+      "**Causa probable:** El proyecto contiene imágenes adjuntas con tamaño mayor a 5 MB, lo que activa un bug conocido en la versión 2.x que genera el PDF vacío.\n",
+      "\n",
+      "**Solución inmediata:**\n",
+      "1. Identificá los adjuntos del proyecto con tamaño mayor a 5 MB desde la vista de archivos.\n",
+      "2. Eliminá o reemplazá esos adjuntos temporalmente.\n",
+      "3. Volvé a exportar a PDF.\n",
+      "4. Una vez obtenido el archivo, podés restaurar los adjuntos originales.\n",
+      "\n",
+      "**Seguimiento:** Este bug está registrado y será corregido en la versión 2.1. Como alternativa, usá la exportación a Excel que no tiene esta limitación.\n",
+      "\n",
+      "User: Moví una tarea a 'Completado' hace 10 minutos y en la búsqueda global sigue apareciendo como pendiente.\n",
+      "Assistant: **Diagnóstico:** El estado de la tarea en la búsqueda global no refleja el cambio reciente.\n",
+      "\n",
+      "**Causa probable:** El índice de búsqueda global se actualiza cada 5 minutos, por lo que cambios recientes pueden tener un retraso visible.\n",
+      "\n",
+      "**Solución inmediata:**\n",
+      "1. Esperá hasta 5 minutos y volvé a buscar.\n",
+      "2. Si el problema persiste más de 10 minutos, forzá una reindexación desde Configuración > Búsqueda > Reindexar workspace.\n",
+      "\n",
+      "**Seguimiento:** Este comportamiento es esperado. Si necesitás resultados en tiempo real, usá los filtros de la vista de lista en lugar de la búsqueda global.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Initial score : {result.initial_score:.2f} / 1.00  (LLM judge · {result.n_examples} examples)\")\n",
+    "print(f\"Final score   : {result.final_score:.2f} / 1.00  (LLM judge · {result.n_examples} examples)\")\n",
+    "print(f\"Trials run    : {result.trials_run}\")\n",
+    "print()\n",
+    "print(\"=== Seed prompt ===\")\n",
+    "print(\"Eres un agente de soporte técnico.\")\n",
+    "print()\n",
+    "print(\"=== Optimized instruction ===\")\n",
+    "print(result.optimized_instruction)\n",
+    "print()\n",
+    "print(\"=== Selected examples ===\")\n",
+    "for demo in result.demos:\n",
+    "    print(f\"User: {demo.query}\")\n",
+    "    print(f\"Assistant: {demo.response}\")\n",
+    "    print()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/fair_forge/prompt_optimizer/__init__.py
+++ b/fair_forge/prompt_optimizer/__init__.py
@@ -1,0 +1,18 @@
+"""Fair Forge prompt optimizer.
+
+Prompt optimization tools for improving AI system prompts based on metric results.
+
+Import optimizers directly from their modules:
+    from fair_forge.prompt_optimizer.gepa import GEPAOptimizer
+    from fair_forge.prompt_optimizer.mipro import MIPROv2Optimizer
+"""
+
+from fair_forge.prompt_optimizer.evaluators import LLMEvaluator
+from fair_forge.prompt_optimizer.gepa import GEPAOptimizer
+from fair_forge.prompt_optimizer.mipro import MIPROv2Optimizer
+
+__all__ = [
+    "GEPAOptimizer",
+    "LLMEvaluator",
+    "MIPROv2Optimizer",
+]

--- a/fair_forge/prompt_optimizer/base.py
+++ b/fair_forge/prompt_optimizer/base.py
@@ -1,0 +1,36 @@
+"""BaseOptimizer abstract class for prompt optimization strategies."""
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fair_forge.core.retriever import Retriever
+    from fair_forge.prompt_optimizer.schemas import OptimizationResult
+
+
+class BaseOptimizer(ABC):
+    """Abstract base class for prompt optimizers.
+
+    Follows the same pattern as FairForge metrics:
+        GEPAOptimizer.run(RetrieverClass, seed_prompt=..., model=..., ...)
+    """
+
+    def __init__(self, retriever: type["Retriever"], **kwargs):
+        from fair_forge.schemas.common import Dataset
+
+        raw = retriever(**kwargs).load_dataset()
+        self.dataset: list[Dataset] = list(raw)  # type: ignore[arg-type]
+
+        if self.dataset and not isinstance(self.dataset[0], Dataset):
+            raise TypeError(
+                "Prompt optimizers require a Retriever that returns list[Dataset]. "
+                "StreamedBatch retrievers are not supported."
+            )
+
+    @classmethod
+    def run(cls, retriever: type["Retriever"], **kwargs) -> "OptimizationResult":
+        return cls(retriever, **kwargs)._optimize()
+
+    @abstractmethod
+    def _optimize(self) -> "OptimizationResult":
+        raise NotImplementedError

--- a/fair_forge/prompt_optimizer/evaluators.py
+++ b/fair_forge/prompt_optimizer/evaluators.py
@@ -1,0 +1,47 @@
+"""Pre-built evaluators for the GEPA prompt optimizer."""
+
+import re
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+
+
+class LLMEvaluator:
+    """Evaluates AI responses using an LLM judge with a natural language criteria.
+
+    Drop-in replacement for a custom evaluator function. The user describes
+    what a good response looks like in plain language — no scoring code needed.
+
+    Usage:
+        evaluator = LLMEvaluator(
+            model=ChatGroq(model="llama-3.3-70b-versatile"),
+            criteria="The response must answer using only the provided context, without hallucinating.",
+        )
+    """
+
+    def __init__(self, model: BaseChatModel, criteria: str):
+        self._model = model
+        self._criteria = criteria
+
+    def __call__(self, actual: str, expected: str, query: str, context: str) -> float:
+        system = (
+            f"You are a response quality evaluator.\n\n"
+            f"Criteria: {self._criteria}\n\n"
+            f"Query: {query}\n"
+            f"Context: {context}\n"
+            f"Expected response: {expected}\n"
+            f"Actual response: {actual}\n\n"
+            'Score the response. Return ONLY a JSON object like: {"score": 0.85}'
+        )
+        response = self._model.invoke([
+            SystemMessage(content=system),
+            HumanMessage(content="Provide the score."),
+        ])
+        return self._parse_score(str(response.content))
+
+    @staticmethod
+    def _parse_score(text: str) -> float:
+        match = re.search(r'"score"\s*:\s*([0-9]*\.?[0-9]+)', text)
+        if match:
+            return max(0.0, min(1.0, float(match.group(1))))
+        return 0.0

--- a/fair_forge/prompt_optimizer/gepa/__init__.py
+++ b/fair_forge/prompt_optimizer/gepa/__init__.py
@@ -1,0 +1,5 @@
+"""GEPA (Generative Evolutionary Prompt Adaptation) optimizer."""
+
+from fair_forge.prompt_optimizer.gepa.gepa import GEPAOptimizer
+
+__all__ = ["GEPAOptimizer"]

--- a/fair_forge/prompt_optimizer/gepa/gepa.py
+++ b/fair_forge/prompt_optimizer/gepa/gepa.py
@@ -1,0 +1,183 @@
+"""GEPA: Generative Evolutionary Prompt Adaptation optimizer."""
+
+from typing import TYPE_CHECKING
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+from tqdm.auto import tqdm
+
+from fair_forge.prompt_optimizer.base import BaseOptimizer
+from fair_forge.prompt_optimizer.gepa.prompts import GENERATION_SYSTEM_PROMPT, GENERATION_USER_PROMPT
+from fair_forge.prompt_optimizer.protocols import Evaluator, Executor
+from fair_forge.prompt_optimizer.schemas import (
+    CandidateResult,
+    FailingExample,
+    IterationResult,
+    OptimizationResult,
+)
+
+if TYPE_CHECKING:
+    from fair_forge.core.retriever import Retriever
+
+
+class _CandidatePrompts(BaseModel):
+    candidates: list[str] = Field(description="List of improved system prompt candidates")
+
+
+class GEPAOptimizer(BaseOptimizer):
+    """Prompt optimizer using GEPA (Generative Evolutionary Prompt Adaptation).
+
+    Iteratively evaluates a system prompt against a dataset, identifies failures,
+    and generates improved candidates via an LLM until the score converges or
+    the iteration budget is exhausted.
+
+    Usage:
+        result = GEPAOptimizer.run(
+            retriever=MyRetriever,
+            model=ChatGroq(model="llama-3.3-70b-versatile"),
+            seed_prompt="You are a helpful assistant.",
+            executor=lambda prompt, query, context: my_agent.call(prompt, query, context),
+            objective="Answer questions accurately using only the provided context.",
+        )
+        print(result.optimized_prompt)
+
+    For structured/deterministic evaluation, pass a custom evaluator:
+        result = GEPAOptimizer.run(..., evaluator=my_evaluator_fn)
+    """
+
+    def __init__(
+        self,
+        retriever: type["Retriever"],
+        model: BaseChatModel,
+        seed_prompt: str,
+        objective: str,
+        executor: Executor | None = None,
+        evaluator: Evaluator | None = None,
+        iterations: int = 5,
+        candidates_per_iteration: int = 3,
+        failure_threshold: float = 0.6,
+        **kwargs,
+    ):
+        super().__init__(retriever, **kwargs)
+        from fair_forge.prompt_optimizer.evaluators import LLMEvaluator
+
+        self.model = model
+        self.seed_prompt = seed_prompt
+        self.objective = objective
+        self.executor = executor or self._default_executor()
+        self.evaluator = evaluator or LLMEvaluator(model=model, criteria=objective)
+        self.iterations = iterations
+        self.candidates_per_iteration = candidates_per_iteration
+        self.failure_threshold = failure_threshold
+
+    def _default_executor(self) -> Executor:
+        model = self.model
+
+        def _execute(prompt: str, query: str, context: str) -> str:
+            system = f"{prompt}\n\n{context}" if context else prompt
+            response = model.invoke([SystemMessage(content=system), HumanMessage(content=query)])
+            return str(response.content)
+
+        return _execute
+
+    def _evaluate_prompt(self, prompt: str) -> tuple[float, list[FailingExample]]:
+        scores: list[float] = []
+        failing: list[FailingExample] = []
+
+        for dataset in self.dataset:
+            for batch in dataset.conversation:
+                actual = self.executor(prompt, batch.query, dataset.context)
+                score = self.evaluator(actual, batch.ground_truth_assistant, batch.query, dataset.context)
+                scores.append(score)
+
+                if score < self.failure_threshold:
+                    failing.append(
+                        FailingExample(
+                            query=batch.query,
+                            context=dataset.context,
+                            expected=batch.ground_truth_assistant,
+                            actual=actual,
+                            score=score,
+                        )
+                    )
+
+        aggregate = sum(scores) / len(scores) if scores else 0.0
+        return aggregate, failing
+
+    def _generate_candidates(self, current_prompt: str, failing: list[FailingExample]) -> list[str]:
+        examples_text = self._format_failing_examples(failing)
+        messages = [
+            SystemMessage(content=GENERATION_SYSTEM_PROMPT),
+            HumanMessage(
+                content=GENERATION_USER_PROMPT.format(
+                    objective=self.objective,
+                    current_prompt=current_prompt,
+                    failing_examples=examples_text,
+                    n=self.candidates_per_iteration,
+                )
+            ),
+        ]
+        structured_model = self.model.with_structured_output(_CandidatePrompts)
+        result: _CandidatePrompts = structured_model.invoke(messages)  # type: ignore[assignment]
+        return result.candidates[: self.candidates_per_iteration]
+
+    def _format_failing_examples(self, failing: list[FailingExample]) -> str:
+        lines = []
+        for i, ex in enumerate(failing[:10], 1):
+            lines.append(
+                f"Example {i}:\n"
+                f"  Query: {ex.query}\n"
+                f"  Expected: {ex.expected}\n"
+                f"  Actual: {ex.actual}\n"
+                f"  Score: {ex.score:.2f}"
+            )
+        return "\n\n".join(lines)
+
+    def _optimize(self) -> OptimizationResult:
+        n_examples = sum(len(d.conversation) for d in self.dataset)
+        print(f"Evaluating seed prompt on {n_examples} examples...")
+        current_score, failing = self._evaluate_prompt(self.seed_prompt)
+        initial_score = current_score
+        current_prompt = self.seed_prompt
+        history: list[IterationResult] = []
+
+        with tqdm(total=self.iterations, desc="Optimizing prompt") as pbar:
+            for i in range(self.iterations):
+                if not failing:
+                    break
+
+                raw_candidates = self._generate_candidates(current_prompt, failing)
+                evaluated = [(cp, *self._evaluate_prompt(cp)) for cp in raw_candidates]
+
+                candidates = [CandidateResult(prompt=cp, score=score) for cp, score, _ in evaluated]
+                best_cp, best_score, best_failing = max(evaluated, key=lambda x: x[1])
+
+                history.append(
+                    IterationResult(
+                        iteration=i + 1,
+                        best_prompt=best_cp,
+                        best_score=best_score,
+                        candidates=candidates,
+                        failing_examples=failing,
+                    )
+                )
+
+                pbar.update(1)
+                pbar.set_postfix({"best": f"{best_score:.2f}", "failing": len(best_failing)})
+
+                if best_score > current_score:
+                    current_prompt = best_cp
+                    current_score = best_score
+                    failing = best_failing
+                else:
+                    break
+
+        return OptimizationResult(
+            optimized_prompt=current_prompt,
+            initial_score=initial_score,
+            final_score=current_score,
+            iterations_run=len(history),
+            n_examples=n_examples,
+            history=history,
+        )

--- a/fair_forge/prompt_optimizer/gepa/prompts.py
+++ b/fair_forge/prompt_optimizer/gepa/prompts.py
@@ -1,0 +1,23 @@
+"""Prompt templates used by the GEPA optimizer for candidate generation."""
+
+GENERATION_SYSTEM_PROMPT = """\
+You are an expert prompt engineer specializing in optimizing system prompts for AI assistants.
+Your task is to analyze failing examples and generate improved system prompts that fix the failures \
+while preserving the original intent.\
+"""
+
+GENERATION_USER_PROMPT = """\
+Objective: {objective}
+
+Current system prompt:
+---
+{current_prompt}
+---
+
+The following examples show where the current prompt produces unsatisfactory results:
+
+{failing_examples}
+
+Generate exactly {n} improved system prompt(s). Each must be a complete, standalone system prompt — \
+not a comment, not a diff, not an explanation. Address the failures directly.\
+"""

--- a/fair_forge/prompt_optimizer/mipro/__init__.py
+++ b/fair_forge/prompt_optimizer/mipro/__init__.py
@@ -1,0 +1,3 @@
+from fair_forge.prompt_optimizer.mipro.mipro import MIPROv2Optimizer
+
+__all__ = ["MIPROv2Optimizer"]

--- a/fair_forge/prompt_optimizer/mipro/mipro.py
+++ b/fair_forge/prompt_optimizer/mipro/mipro.py
@@ -1,0 +1,176 @@
+"""MIPROv2: Multiprompt Instruction PRoposal Optimizer v2."""
+
+import random
+from typing import TYPE_CHECKING
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from tqdm.auto import tqdm
+
+from fair_forge.prompt_optimizer.base import BaseOptimizer
+from fair_forge.prompt_optimizer.mipro.proposer import DemoBootstrapper, InstructionProposer
+from fair_forge.prompt_optimizer.protocols import Evaluator, Executor
+from fair_forge.prompt_optimizer.schemas import Demo, MIPROv2Result, TrialResult
+
+if TYPE_CHECKING:
+    from fair_forge.core.retriever import Retriever
+
+
+class MIPROv2Optimizer(BaseOptimizer):
+    """Prompt optimizer using MIPROv2 (Multiprompt Instruction PRoposal Optimizer v2).
+
+    Combines instruction proposal with few-shot demo bootstrapping, then uses
+    Bayesian Optimization (Optuna/TPE) to find the best (instruction, demo_set) combination.
+
+    Usage:
+        result = MIPROv2Optimizer.run(
+            retriever=MyRetriever,
+            model=ChatGroq(model="llama-3.3-70b-versatile"),
+            seed_prompt="You are a helpful assistant.",
+            objective="Answer questions using only the provided context.",
+        )
+        print(result.optimized_prompt)
+    """
+
+    def __init__(
+        self,
+        retriever: type["Retriever"],
+        model: BaseChatModel,
+        seed_prompt: str,
+        objective: str,
+        executor: Executor | None = None,
+        evaluator: Evaluator | None = None,
+        num_candidates: int = 10,
+        num_trials: int = 20,
+        minibatch_size: int = 25,
+        max_demos_per_set: int = 3,
+        num_demo_sets: int = 5,
+        random_seed: int = 42,
+        **kwargs,
+    ):
+        super().__init__(retriever, **kwargs)
+        from fair_forge.prompt_optimizer.evaluators import LLMEvaluator
+
+        self._model = model
+        self._seed_prompt = seed_prompt
+        self._objective = objective
+        self._executor = executor or self._default_executor()
+        self._evaluator = evaluator or LLMEvaluator(model=model, criteria=objective)
+        self._num_candidates = num_candidates
+        self._num_trials = num_trials
+        self._minibatch_size = minibatch_size
+        self._max_demos_per_set = max_demos_per_set
+        self._num_demo_sets = num_demo_sets
+        self._random_seed = random_seed
+        self._rng = random.Random(random_seed)
+
+    def _default_executor(self) -> Executor:
+        model = self._model
+
+        def _execute(prompt: str, query: str, context: str) -> str:
+            system = f"{prompt}\n\n{context}" if context else prompt
+            return str(model.invoke([SystemMessage(content=system), HumanMessage(content=query)]).content)
+
+        return _execute
+
+    def _collect_examples(self) -> list[tuple[str, object]]:
+        return [
+            (dataset.context, batch)
+            for dataset in self.dataset
+            for batch in dataset.conversation
+        ]
+
+    def _score_examples(self, prompt: str, examples: list[tuple[str, object]]) -> float:
+        scores = [
+            self._evaluator(
+                self._executor(prompt, batch.query, context),  # type: ignore[union-attr]
+                batch.ground_truth_assistant,  # type: ignore[union-attr]
+                batch.query,  # type: ignore[union-attr]
+                context,
+            )
+            for context, batch in examples
+        ]
+        return sum(scores) / len(scores) if scores else 0.0
+
+    def _evaluate_prompt(self, prompt: str, minibatch: bool = False) -> float:
+        examples = self._collect_examples()
+        if minibatch and len(examples) > self._minibatch_size:
+            examples = self._rng.sample(examples, self._minibatch_size)
+        return self._score_examples(prompt, examples)
+
+    def _build_prompt(self, instruction: str, demos: list[Demo]) -> str:
+        if not demos:
+            return instruction
+        examples = "\n\n".join(f"User: {d.query}\nAssistant: {d.response}" for d in demos)
+        return f"{instruction}\n\nExamples:\n{examples}"
+
+    def _optimize(self) -> MIPROv2Result:
+        try:
+            import optuna
+            optuna.logging.set_verbosity(optuna.logging.WARNING)
+        except ImportError:
+            raise ImportError(
+                "MIPROv2Optimizer requires optuna. Install it with: pip install optuna"
+            )
+
+        n_examples = sum(len(d.conversation) for d in self.dataset)
+        print(f"Evaluating seed prompt on {n_examples} examples...")
+        initial_score = self._evaluate_prompt(self._seed_prompt)
+
+        print(f"Generating {self._num_candidates} instruction candidates...")
+        instructions = InstructionProposer(
+            model=self._model,
+            seed_prompt=self._seed_prompt,
+            objective=self._objective,
+            num_candidates=self._num_candidates,
+        ).propose()
+
+        demo_sets = DemoBootstrapper(
+            dataset=self.dataset,
+            num_demo_sets=self._num_demo_sets,
+            max_demos_per_set=self._max_demos_per_set,
+            random_seed=self._random_seed,
+        ).bootstrap()
+
+        trial_results: list[TrialResult] = []
+
+        with tqdm(total=self._num_trials, desc="Evaluating trials") as pbar:
+
+            def objective_fn(trial: "optuna.Trial") -> float:
+                instruction_idx = trial.suggest_int("instruction_idx", 0, len(instructions) - 1)
+                demo_set_idx = trial.suggest_int("demo_set_idx", 0, len(demo_sets) - 1)
+                prompt = self._build_prompt(instructions[instruction_idx], demo_sets[demo_set_idx])
+                score = self._evaluate_prompt(prompt, minibatch=True)
+                trial_results.append(
+                    TrialResult(
+                        trial=trial.number,
+                        instruction_idx=instruction_idx,
+                        demo_set_idx=demo_set_idx,
+                        score=score,
+                    )
+                )
+                best = max(t.score for t in trial_results)
+                pbar.set_postfix({"best": f"{best:.2f}"})
+                pbar.update(1)
+                return score
+
+            study = optuna.create_study(
+                direction="maximize",
+                sampler=optuna.samplers.TPESampler(seed=self._random_seed),
+            )
+            study.optimize(objective_fn, n_trials=self._num_trials)
+
+        best = study.best_trial
+        best_instruction = instructions[best.params["instruction_idx"]]
+        best_demos = demo_sets[best.params["demo_set_idx"]]
+
+        return MIPROv2Result(
+            optimized_prompt=self._build_prompt(best_instruction, best_demos),
+            optimized_instruction=best_instruction,
+            initial_score=initial_score,
+            final_score=study.best_value,
+            trials_run=len(study.trials),
+            n_examples=n_examples,
+            demos=best_demos,
+            trials=trial_results,
+        )

--- a/fair_forge/prompt_optimizer/mipro/mipro.py
+++ b/fair_forge/prompt_optimizer/mipro/mipro.py
@@ -46,6 +46,9 @@ class MIPROv2Optimizer(BaseOptimizer):
         max_demos_per_set: int = 3,
         num_demo_sets: int = 5,
         random_seed: int = 42,
+        tips: list[str] | None = None,
+        instruction_proposal_system: str | None = None,
+        instruction_proposal_user: str | None = None,
         **kwargs,
     ):
         super().__init__(retriever, **kwargs)
@@ -63,6 +66,9 @@ class MIPROv2Optimizer(BaseOptimizer):
         self._num_demo_sets = num_demo_sets
         self._random_seed = random_seed
         self._rng = random.Random(random_seed)
+        self._tips = tips
+        self._instruction_proposal_system = instruction_proposal_system
+        self._instruction_proposal_user = instruction_proposal_user
 
     def _default_executor(self) -> Executor:
         model = self._model
@@ -123,6 +129,9 @@ class MIPROv2Optimizer(BaseOptimizer):
             seed_prompt=self._seed_prompt,
             objective=self._objective,
             num_candidates=self._num_candidates,
+            tips=self._tips,
+            system_prompt=self._instruction_proposal_system,
+            user_prompt=self._instruction_proposal_user,
         ).propose()
 
         demo_sets = DemoBootstrapper(

--- a/fair_forge/prompt_optimizer/mipro/prompts.py
+++ b/fair_forge/prompt_optimizer/mipro/prompts.py
@@ -1,0 +1,19 @@
+"""Prompt templates used by the MIPROv2 optimizer for instruction proposal."""
+
+INSTRUCTION_PROPOSAL_SYSTEM = """\
+You are an expert prompt engineer. Your task is to generate diverse system prompt variants from a seed prompt.
+Each variant must preserve the original objective but emphasize a different aspect of good behavior.\
+"""
+
+INSTRUCTION_PROPOSAL_USER = """\
+Seed prompt: {seed_prompt}
+Objective: {objective}
+
+Generate exactly {n} system prompt variants. Each variant must emphasize the corresponding focus area:
+{tips}
+
+Rules:
+- Each variant must be a complete, standalone system prompt.
+- Do not include the focus area label or number in the variant itself.
+- Vary the phrasing and emphasis across variants — avoid generating near-identical prompts.\
+"""

--- a/fair_forge/prompt_optimizer/mipro/proposer.py
+++ b/fair_forge/prompt_optimizer/mipro/proposer.py
@@ -1,0 +1,70 @@
+"""Instruction proposal and demo bootstrapping for MIPROv2."""
+
+import random
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from fair_forge.prompt_optimizer.mipro.prompts import INSTRUCTION_PROPOSAL_SYSTEM, INSTRUCTION_PROPOSAL_USER
+from fair_forge.prompt_optimizer.schemas import Demo
+
+_TIPS = [
+    "Be explicit about what the model should NOT do.",
+    "Specify the expected output format and structure.",
+    "Define the tone and communication style.",
+    "Emphasize grounding responses in the provided context only.",
+    "Prioritize conciseness — fewer words, more precision.",
+    "Address edge cases and ambiguous or out-of-scope queries.",
+    "Make the constraints actionable and specific.",
+    "Emphasize what differentiates an excellent response from a mediocre one.",
+    "Focus on the user's underlying need, not just the literal question.",
+    "Be explicit about when to say you don't know.",
+]
+
+
+class _InstructionVariants(BaseModel):
+    instructions: list[str] = Field(description="List of system prompt variants, one per focus area")
+
+
+class InstructionProposer:
+    def __init__(self, model: BaseChatModel, seed_prompt: str, objective: str, num_candidates: int):
+        self._model = model
+        self._seed_prompt = seed_prompt
+        self._objective = objective
+        self._num_candidates = num_candidates
+
+    def propose(self) -> list[str]:
+        tips = [_TIPS[i % len(_TIPS)] for i in range(self._num_candidates)]
+        tips_text = "\n".join(f"{i + 1}. {tip}" for i, tip in enumerate(tips))
+        messages = [
+            SystemMessage(content=INSTRUCTION_PROPOSAL_SYSTEM),
+            HumanMessage(
+                content=INSTRUCTION_PROPOSAL_USER.format(
+                    seed_prompt=self._seed_prompt,
+                    objective=self._objective,
+                    n=self._num_candidates,
+                    tips=tips_text,
+                )
+            ),
+        ]
+        structured = self._model.with_structured_output(_InstructionVariants)
+        result: _InstructionVariants = structured.invoke(messages)  # type: ignore[assignment]
+        return result.instructions[: self._num_candidates]
+
+
+class DemoBootstrapper:
+    def __init__(self, dataset: list, num_demo_sets: int, max_demos_per_set: int, random_seed: int):
+        self._dataset = dataset
+        self._num_demo_sets = num_demo_sets
+        self._max_demos_per_set = max_demos_per_set
+        self._rng = random.Random(random_seed)
+
+    def bootstrap(self) -> list[list[Demo]]:
+        all_demos = [
+            Demo(query=batch.query, response=batch.ground_truth_assistant)
+            for dataset in self._dataset
+            for batch in dataset.conversation
+        ]
+        n = min(self._max_demos_per_set, len(all_demos))
+        return [self._rng.sample(all_demos, n) for _ in range(self._num_demo_sets)]

--- a/fair_forge/prompt_optimizer/mipro/proposer.py
+++ b/fair_forge/prompt_optimizer/mipro/proposer.py
@@ -28,19 +28,31 @@ class _InstructionVariants(BaseModel):
 
 
 class InstructionProposer:
-    def __init__(self, model: BaseChatModel, seed_prompt: str, objective: str, num_candidates: int):
+    def __init__(
+        self,
+        model: BaseChatModel,
+        seed_prompt: str,
+        objective: str,
+        num_candidates: int,
+        tips: list[str] | None = None,
+        system_prompt: str | None = None,
+        user_prompt: str | None = None,
+    ):
         self._model = model
         self._seed_prompt = seed_prompt
         self._objective = objective
         self._num_candidates = num_candidates
+        self._tips = tips or _TIPS
+        self._system_prompt = system_prompt or INSTRUCTION_PROPOSAL_SYSTEM
+        self._user_prompt = user_prompt or INSTRUCTION_PROPOSAL_USER
 
     def propose(self) -> list[str]:
-        tips = [_TIPS[i % len(_TIPS)] for i in range(self._num_candidates)]
+        tips = [self._tips[i % len(self._tips)] for i in range(self._num_candidates)]
         tips_text = "\n".join(f"{i + 1}. {tip}" for i, tip in enumerate(tips))
         messages = [
-            SystemMessage(content=INSTRUCTION_PROPOSAL_SYSTEM),
+            SystemMessage(content=self._system_prompt),
             HumanMessage(
-                content=INSTRUCTION_PROPOSAL_USER.format(
+                content=self._user_prompt.format(
                     seed_prompt=self._seed_prompt,
                     objective=self._objective,
                     n=self._num_candidates,

--- a/fair_forge/prompt_optimizer/miprov2/__init__.py
+++ b/fair_forge/prompt_optimizer/miprov2/__init__.py
@@ -1,0 +1,3 @@
+"""MIPROv2 (Multi-prompt Instruction Proposal Optimizer v2) optimizer."""
+
+__all__ = ["MIPROv2Optimizer"]

--- a/fair_forge/prompt_optimizer/protocols.py
+++ b/fair_forge/prompt_optimizer/protocols.py
@@ -1,0 +1,17 @@
+"""Protocols defining the interfaces required by prompt optimizers."""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Executor(Protocol):
+    """Runs the AI system under optimization with a given system prompt."""
+
+    def __call__(self, prompt: str, query: str, context: str) -> str: ...
+
+
+@runtime_checkable
+class Evaluator(Protocol):
+    """Scores an AI response against the expected output. Returns a float in [0.0, 1.0]."""
+
+    def __call__(self, actual: str, expected: str, query: str, context: str) -> float: ...

--- a/fair_forge/prompt_optimizer/schemas.py
+++ b/fair_forge/prompt_optimizer/schemas.py
@@ -1,0 +1,56 @@
+"""Shared schemas for prompt optimization results."""
+
+from pydantic import BaseModel
+
+
+class FailingExample(BaseModel):
+    query: str
+    context: str
+    expected: str
+    actual: str
+    score: float
+
+
+class CandidateResult(BaseModel):
+    prompt: str
+    score: float
+
+
+class IterationResult(BaseModel):
+    iteration: int
+    best_prompt: str
+    best_score: float
+    candidates: list[CandidateResult]
+    failing_examples: list[FailingExample]
+
+
+class OptimizationResult(BaseModel):
+    optimized_prompt: str
+    initial_score: float
+    final_score: float
+    iterations_run: int
+    n_examples: int
+    history: list[IterationResult]
+
+
+class Demo(BaseModel):
+    query: str
+    response: str
+
+
+class TrialResult(BaseModel):
+    trial: int
+    instruction_idx: int
+    demo_set_idx: int
+    score: float
+
+
+class MIPROv2Result(BaseModel):
+    optimized_prompt: str
+    optimized_instruction: str
+    initial_score: float
+    final_score: float
+    trials_run: int
+    n_examples: int
+    demos: list[Demo]
+    trials: list[TrialResult]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "loguru>=0.7.3",
     # Tokenizers (required for schemas)
     "transformers>=4.35.0",
+    "optuna>=4.7.0",
 ]
 
 [project.optional-dependencies]
@@ -115,6 +116,11 @@ runners = [
     "aiosseclient>=0.1.8",
 ]
 
+# Prompt optimizer module
+prompt-optimizer = [
+    "optuna>=3.0.0",
+]
+
 # Generators module (base - requires user to install their LLM provider)
 generators = []
 
@@ -125,7 +131,7 @@ generators-alquimia = [
 
 # Everything
 all = [
-    "alquimia-fair-forge[metrics,runners,generators,generators-alquimia,explainability]",
+    "alquimia-fair-forge[metrics,runners,generators,generators-alquimia,explainability,prompt-optimizer]",
 ]
 
 # Development tools

--- a/tests/prompt_optimizer/conftest.py
+++ b/tests/prompt_optimizer/conftest.py
@@ -1,0 +1,53 @@
+import pytest
+from unittest.mock import MagicMock
+
+from fair_forge.core.retriever import Retriever
+from fair_forge.schemas.common import Batch, Dataset
+
+
+def _make_batch(qa_id: str, query: str) -> Batch:
+    return Batch(
+        qa_id=qa_id,
+        query=query,
+        assistant="",
+        ground_truth_assistant=f"Expected answer for: {query}",
+        ground_truth_agentic={},
+    )
+
+
+def _make_dataset(session_id: str, context: str, queries: list[str]) -> Dataset:
+    return Dataset(
+        session_id=session_id,
+        assistant_id="test-bot",
+        language="english",
+        context=context,
+        conversation=[_make_batch(f"{session_id}-{i}", q) for i, q in enumerate(queries)],
+    )
+
+
+MOCK_DATASETS = [
+    _make_dataset("session-1", "Context about topic A.", ["Query 1A", "Query 2A"]),
+    _make_dataset("session-2", "Context about topic B.", ["Query 1B", "Query 2B"]),
+]
+
+
+class PromptOptimizerRetriever(Retriever):
+    def load_dataset(self) -> list[Dataset]:
+        return MOCK_DATASETS
+
+
+@pytest.fixture
+def mock_model():
+    model = MagicMock()
+    model.invoke.return_value = MagicMock(content='{"score": 0.8}')
+    return model
+
+
+@pytest.fixture
+def mock_executor():
+    return MagicMock(return_value="Mock executor response.")
+
+
+@pytest.fixture
+def mock_evaluator():
+    return MagicMock(return_value=0.8)

--- a/tests/prompt_optimizer/test_evaluators.py
+++ b/tests/prompt_optimizer/test_evaluators.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import MagicMock
+
+from fair_forge.prompt_optimizer.evaluators import LLMEvaluator
+
+
+class TestLLMEvaluatorParseScore:
+    def test_valid_json_score(self):
+        assert LLMEvaluator._parse_score('{"score": 0.85}') == pytest.approx(0.85)
+
+    def test_score_with_spaces(self):
+        assert LLMEvaluator._parse_score('{"score" : 0.5}') == pytest.approx(0.5)
+
+    def test_integer_score(self):
+        assert LLMEvaluator._parse_score('{"score": 1}') == pytest.approx(1.0)
+
+    def test_clamps_above_one(self):
+        assert LLMEvaluator._parse_score('{"score": 1.5}') == pytest.approx(1.0)
+
+    def test_clamps_below_zero(self):
+        assert LLMEvaluator._parse_score('{"score": -0.1}') == pytest.approx(0.0)
+
+    def test_invalid_returns_zero(self):
+        assert LLMEvaluator._parse_score("no score here") == pytest.approx(0.0)
+
+    def test_empty_string_returns_zero(self):
+        assert LLMEvaluator._parse_score("") == pytest.approx(0.0)
+
+    def test_score_embedded_in_text(self):
+        assert LLMEvaluator._parse_score('Here is my eval: {"score": 0.72}') == pytest.approx(0.72)
+
+
+class TestLLMEvaluatorCall:
+    def test_returns_parsed_score(self, mock_model):
+        mock_model.invoke.return_value = MagicMock(content='{"score": 0.75}')
+        evaluator = LLMEvaluator(model=mock_model, criteria="Test criteria.")
+        score = evaluator("actual response", "expected response", "query", "context")
+        assert score == pytest.approx(0.75)
+
+    def test_calls_model_once(self, mock_model):
+        mock_model.invoke.return_value = MagicMock(content='{"score": 0.5}')
+        evaluator = LLMEvaluator(model=mock_model, criteria="criteria")
+        evaluator("actual", "expected", "query", "context")
+        mock_model.invoke.assert_called_once()
+
+    def test_invalid_model_response_returns_zero(self, mock_model):
+        mock_model.invoke.return_value = MagicMock(content="I think this looks good.")
+        evaluator = LLMEvaluator(model=mock_model, criteria="criteria")
+        score = evaluator("actual", "expected", "query", "context")
+        assert score == pytest.approx(0.0)
+
+    def test_boundary_score_zero(self, mock_model):
+        mock_model.invoke.return_value = MagicMock(content='{"score": 0.0}')
+        evaluator = LLMEvaluator(model=mock_model, criteria="criteria")
+        assert evaluator("a", "e", "q", "c") == pytest.approx(0.0)
+
+    def test_boundary_score_one(self, mock_model):
+        mock_model.invoke.return_value = MagicMock(content='{"score": 1.0}')
+        evaluator = LLMEvaluator(model=mock_model, criteria="criteria")
+        assert evaluator("a", "e", "q", "c") == pytest.approx(1.0)

--- a/tests/prompt_optimizer/test_gepa.py
+++ b/tests/prompt_optimizer/test_gepa.py
@@ -1,0 +1,224 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from fair_forge.prompt_optimizer.evaluators import LLMEvaluator
+from fair_forge.prompt_optimizer.gepa import GEPAOptimizer
+from fair_forge.prompt_optimizer.schemas import OptimizationResult
+
+from tests.prompt_optimizer.conftest import PromptOptimizerRetriever
+
+
+class TestGEPAInitialization:
+    def test_default_evaluator_is_llm_evaluator(self, mock_model, mock_executor):
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective", executor=mock_executor,
+        )
+        assert isinstance(optimizer.evaluator, LLMEvaluator)
+
+    def test_custom_evaluator_is_used(self, mock_model, mock_executor, mock_evaluator):
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=mock_evaluator,
+        )
+        assert optimizer.evaluator is mock_evaluator
+
+    def test_custom_executor_is_used(self, mock_model, mock_executor):
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective", executor=mock_executor,
+        )
+        assert optimizer.executor is mock_executor
+
+    def test_default_iterations(self, mock_model, mock_executor):
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective", executor=mock_executor,
+        )
+        assert optimizer.iterations == 5
+
+    def test_custom_iterations(self, mock_model, mock_executor):
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, iterations=3,
+        )
+        assert optimizer.iterations == 3
+
+    def test_dataset_loaded_from_retriever(self, mock_model, mock_executor):
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective", executor=mock_executor,
+        )
+        assert len(optimizer.dataset) == 2
+
+
+class TestGEPAEvaluatePrompt:
+    def test_returns_average_score(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=0.6)
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator,
+        )
+        score, _ = optimizer._evaluate_prompt("test prompt")
+        assert score == pytest.approx(0.6)
+
+    def test_failing_examples_collected_below_threshold(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=0.3)
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator, failure_threshold=0.6,
+        )
+        _, failing = optimizer._evaluate_prompt("prompt")
+        assert len(failing) == 4
+
+    def test_no_failing_when_above_threshold(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=0.9)
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator,
+        )
+        _, failing = optimizer._evaluate_prompt("prompt")
+        assert len(failing) == 0
+
+    def test_executor_called_for_each_example(self, mock_model, mock_executor, mock_evaluator):
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=mock_evaluator,
+        )
+        optimizer._evaluate_prompt("prompt")
+        assert mock_executor.call_count == 4
+
+    def test_failing_example_fields_populated(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=0.2)
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator,
+        )
+        _, failing = optimizer._evaluate_prompt("prompt")
+        assert all(ex.query and ex.expected and ex.actual for ex in failing)
+        assert all(ex.score == pytest.approx(0.2) for ex in failing)
+
+
+class TestGEPAOptimize:
+    def test_stops_immediately_when_no_failing_examples(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=1.0)
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator,
+        )
+        result = optimizer._optimize()
+        assert result.iterations_run == 0
+        assert result.optimized_prompt == "seed"
+
+    def test_result_type(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=1.0)
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator,
+        )
+        result = optimizer._optimize()
+        assert isinstance(result, OptimizationResult)
+
+    def test_n_examples_in_result(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=1.0)
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator,
+        )
+        result = optimizer._optimize()
+        assert result.n_examples == 4
+
+    def test_initial_score_reflects_seed_prompt(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=1.0)
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator,
+        )
+        result = optimizer._optimize()
+        assert result.initial_score == pytest.approx(1.0)
+
+    @patch("fair_forge.prompt_optimizer.gepa.gepa.GEPAOptimizer._generate_candidates")
+    def test_adopts_better_candidate(self, mock_generate, mock_model, mock_executor):
+        mock_generate.return_value = ["improved prompt"]
+        call_count = 0
+
+        def evaluator(actual, expected, query, context):
+            nonlocal call_count
+            call_count += 1
+            # seed evaluation (4 calls) → low, candidate evaluation (4 calls) → high, next eval (4 calls) → perfect
+            if call_count <= 4:
+                return 0.3
+            elif call_count <= 8:
+                return 0.9
+            return 1.0
+
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator,
+        )
+        result = optimizer._optimize()
+        assert result.optimized_prompt == "improved prompt"
+        assert result.final_score > result.initial_score
+
+    @patch("fair_forge.prompt_optimizer.gepa.gepa.GEPAOptimizer._generate_candidates")
+    def test_stops_when_candidate_does_not_improve(self, mock_generate, mock_model, mock_executor):
+        mock_generate.return_value = ["same quality prompt"]
+        evaluator = MagicMock(return_value=0.4)
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator, iterations=5,
+        )
+        result = optimizer._optimize()
+        assert result.iterations_run == 1
+
+    @patch("fair_forge.prompt_optimizer.gepa.gepa.GEPAOptimizer._generate_candidates")
+    def test_history_has_one_entry_per_completed_iteration(self, mock_generate, mock_model, mock_executor):
+        mock_generate.return_value = ["candidate"]
+        evaluator = MagicMock(return_value=0.4)
+        optimizer = GEPAOptimizer(
+            PromptOptimizerRetriever, model=mock_model,
+            seed_prompt="seed", objective="objective",
+            executor=mock_executor, evaluator=evaluator,
+        )
+        result = optimizer._optimize()
+        assert len(result.history) == result.iterations_run
+
+
+class TestGEPARun:
+    def test_run_returns_optimization_result(self, mock_model, mock_executor, mock_evaluator):
+        mock_evaluator.return_value = 1.0
+        result = GEPAOptimizer.run(
+            PromptOptimizerRetriever,
+            model=mock_model,
+            seed_prompt="seed",
+            objective="objective",
+            executor=mock_executor,
+            evaluator=mock_evaluator,
+        )
+        assert isinstance(result, OptimizationResult)
+
+    def test_run_exposes_optimized_prompt(self, mock_model, mock_executor, mock_evaluator):
+        mock_evaluator.return_value = 1.0
+        result = GEPAOptimizer.run(
+            PromptOptimizerRetriever,
+            model=mock_model,
+            seed_prompt="my seed",
+            objective="objective",
+            executor=mock_executor,
+            evaluator=mock_evaluator,
+        )
+        assert isinstance(result.optimized_prompt, str)
+        assert len(result.optimized_prompt) > 0

--- a/tests/prompt_optimizer/test_mipro.py
+++ b/tests/prompt_optimizer/test_mipro.py
@@ -1,0 +1,238 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from fair_forge.prompt_optimizer.mipro import MIPROv2Optimizer
+from fair_forge.prompt_optimizer.mipro.proposer import DemoBootstrapper, InstructionProposer, _InstructionVariants
+from fair_forge.prompt_optimizer.schemas import Demo, MIPROv2Result
+
+from tests.prompt_optimizer.conftest import MOCK_DATASETS, PromptOptimizerRetriever
+
+
+def _make_optimizer(mock_model, mock_executor, mock_evaluator, **kwargs) -> MIPROv2Optimizer:
+    defaults = dict(
+        num_candidates=2,
+        num_trials=2,
+        num_demo_sets=2,
+        max_demos_per_set=2,
+    )
+    defaults.update(kwargs)
+    return MIPROv2Optimizer(
+        PromptOptimizerRetriever, model=mock_model,
+        seed_prompt="seed", objective="objective",
+        executor=mock_executor, evaluator=mock_evaluator,
+        **defaults,
+    )
+
+
+class TestDemoBootstrapper:
+    def test_returns_correct_number_of_demo_sets(self):
+        bootstrapper = DemoBootstrapper(MOCK_DATASETS, num_demo_sets=5, max_demos_per_set=2, random_seed=42)
+        assert len(bootstrapper.bootstrap()) == 5
+
+    def test_demos_respect_max_per_set(self):
+        bootstrapper = DemoBootstrapper(MOCK_DATASETS, num_demo_sets=3, max_demos_per_set=2, random_seed=42)
+        for demo_set in bootstrapper.bootstrap():
+            assert len(demo_set) <= 2
+
+    def test_demos_are_demo_instances(self):
+        bootstrapper = DemoBootstrapper(MOCK_DATASETS, num_demo_sets=3, max_demos_per_set=2, random_seed=42)
+        for demo_set in bootstrapper.bootstrap():
+            assert all(isinstance(d, Demo) for d in demo_set)
+
+    def test_demo_queries_come_from_dataset(self):
+        all_queries = {batch.query for dataset in MOCK_DATASETS for batch in dataset.conversation}
+        bootstrapper = DemoBootstrapper(MOCK_DATASETS, num_demo_sets=3, max_demos_per_set=2, random_seed=42)
+        for demo_set in bootstrapper.bootstrap():
+            assert all(d.query in all_queries for d in demo_set)
+
+    def test_reproducible_with_same_seed(self):
+        b1 = DemoBootstrapper(MOCK_DATASETS, 3, 2, 42).bootstrap()
+        b2 = DemoBootstrapper(MOCK_DATASETS, 3, 2, 42).bootstrap()
+        assert [[d.query for d in ds] for ds in b1] == [[d.query for d in ds] for ds in b2]
+
+    def test_max_demos_capped_by_dataset_size(self):
+        bootstrapper = DemoBootstrapper(MOCK_DATASETS, num_demo_sets=2, max_demos_per_set=100, random_seed=42)
+        for demo_set in bootstrapper.bootstrap():
+            assert len(demo_set) <= 4
+
+
+class TestInstructionProposer:
+    def test_returns_correct_number_of_instructions(self, mock_model):
+        mock_model.with_structured_output.return_value.invoke.return_value = _InstructionVariants(
+            instructions=["inst1", "inst2", "inst3"]
+        )
+        proposer = InstructionProposer(mock_model, "seed", "objective", num_candidates=3)
+        assert len(proposer.propose()) == 3
+
+    def test_calls_model_with_structured_output(self, mock_model):
+        mock_model.with_structured_output.return_value.invoke.return_value = _InstructionVariants(
+            instructions=["inst1"]
+        )
+        proposer = InstructionProposer(mock_model, "seed", "objective", num_candidates=1)
+        proposer.propose()
+        mock_model.with_structured_output.assert_called_once()
+
+    def test_truncates_to_num_candidates(self, mock_model):
+        mock_model.with_structured_output.return_value.invoke.return_value = _InstructionVariants(
+            instructions=["a", "b", "c", "d", "e"]
+        )
+        proposer = InstructionProposer(mock_model, "seed", "objective", num_candidates=3)
+        assert len(proposer.propose()) == 3
+
+    def test_returns_strings(self, mock_model):
+        mock_model.with_structured_output.return_value.invoke.return_value = _InstructionVariants(
+            instructions=["instruction one", "instruction two"]
+        )
+        proposer = InstructionProposer(mock_model, "seed", "objective", num_candidates=2)
+        instructions = proposer.propose()
+        assert all(isinstance(i, str) for i in instructions)
+
+
+class TestMIPROv2BuildPrompt:
+    def test_no_demos_returns_instruction_only(self, mock_model, mock_executor, mock_evaluator):
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        assert optimizer._build_prompt("the instruction", []) == "the instruction"
+
+    def test_with_demos_includes_instruction(self, mock_model, mock_executor, mock_evaluator):
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        demos = [Demo(query="q1", response="r1")]
+        result = optimizer._build_prompt("instruction", demos)
+        assert "instruction" in result
+
+    def test_with_demos_includes_query_and_response(self, mock_model, mock_executor, mock_evaluator):
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        demos = [Demo(query="q1", response="r1"), Demo(query="q2", response="r2")]
+        result = optimizer._build_prompt("instruction", demos)
+        assert "q1" in result and "r1" in result
+        assert "q2" in result and "r2" in result
+
+
+class TestMIPROv2CollectExamples:
+    def test_returns_all_examples(self, mock_model, mock_executor, mock_evaluator):
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        assert len(optimizer._collect_examples()) == 4
+
+    def test_each_example_is_context_batch_tuple(self, mock_model, mock_executor, mock_evaluator):
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        for context, batch in optimizer._collect_examples():
+            assert isinstance(context, str)
+            assert hasattr(batch, "query")
+
+
+class TestMIPROv2ScoreExamples:
+    def test_returns_average_score(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=0.8)
+        optimizer = _make_optimizer(mock_model, mock_executor, evaluator)
+        examples = optimizer._collect_examples()
+        assert optimizer._score_examples("prompt", examples) == pytest.approx(0.8)
+
+    def test_empty_examples_returns_zero(self, mock_model, mock_executor, mock_evaluator):
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        assert optimizer._score_examples("prompt", []) == pytest.approx(0.0)
+
+    def test_evaluator_called_for_each_example(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=0.5)
+        optimizer = _make_optimizer(mock_model, mock_executor, evaluator)
+        examples = optimizer._collect_examples()
+        optimizer._score_examples("prompt", examples)
+        assert evaluator.call_count == 4
+
+
+class TestMIPROv2EvaluatePrompt:
+    def test_uses_all_examples_without_minibatch(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=0.5)
+        optimizer = _make_optimizer(mock_model, mock_executor, evaluator, minibatch_size=2)
+        optimizer._evaluate_prompt("prompt", minibatch=False)
+        assert evaluator.call_count == 4
+
+    def test_uses_minibatch_when_dataset_exceeds_size(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=0.5)
+        optimizer = _make_optimizer(mock_model, mock_executor, evaluator, minibatch_size=2)
+        optimizer._evaluate_prompt("prompt", minibatch=True)
+        assert evaluator.call_count == 2
+
+    def test_uses_all_when_dataset_smaller_than_minibatch(self, mock_model, mock_executor):
+        evaluator = MagicMock(return_value=0.5)
+        optimizer = _make_optimizer(mock_model, mock_executor, evaluator, minibatch_size=100)
+        optimizer._evaluate_prompt("prompt", minibatch=True)
+        assert evaluator.call_count == 4
+
+
+class TestMIPROv2Optimize:
+    @patch("fair_forge.prompt_optimizer.mipro.mipro.InstructionProposer")
+    def test_result_type(self, mock_proposer_class, mock_model, mock_executor, mock_evaluator):
+        mock_proposer_class.return_value.propose.return_value = ["inst1", "inst2"]
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        result = optimizer._optimize()
+        assert isinstance(result, MIPROv2Result)
+
+    @patch("fair_forge.prompt_optimizer.mipro.mipro.InstructionProposer")
+    def test_n_examples_in_result(self, mock_proposer_class, mock_model, mock_executor, mock_evaluator):
+        mock_proposer_class.return_value.propose.return_value = ["inst1", "inst2"]
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        result = optimizer._optimize()
+        assert result.n_examples == 4
+
+    @patch("fair_forge.prompt_optimizer.mipro.mipro.InstructionProposer")
+    def test_demos_are_demo_instances(self, mock_proposer_class, mock_model, mock_executor, mock_evaluator):
+        mock_proposer_class.return_value.propose.return_value = ["inst1", "inst2"]
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        result = optimizer._optimize()
+        assert all(isinstance(d, Demo) for d in result.demos)
+
+    @patch("fair_forge.prompt_optimizer.mipro.mipro.InstructionProposer")
+    def test_trials_run_matches_num_trials(self, mock_proposer_class, mock_model, mock_executor, mock_evaluator):
+        mock_proposer_class.return_value.propose.return_value = ["inst1", "inst2"]
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator, num_trials=2)
+        result = optimizer._optimize()
+        assert result.trials_run == 2
+
+    @patch("fair_forge.prompt_optimizer.mipro.mipro.InstructionProposer")
+    def test_optimized_instruction_is_string(self, mock_proposer_class, mock_model, mock_executor, mock_evaluator):
+        mock_proposer_class.return_value.propose.return_value = ["inst1", "inst2"]
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        result = optimizer._optimize()
+        assert isinstance(result.optimized_instruction, str)
+        assert len(result.optimized_instruction) > 0
+
+    @patch("fair_forge.prompt_optimizer.mipro.mipro.InstructionProposer")
+    def test_optimized_prompt_contains_instruction(self, mock_proposer_class, mock_model, mock_executor, mock_evaluator):
+        mock_proposer_class.return_value.propose.return_value = ["inst1", "inst2"]
+        optimizer = _make_optimizer(mock_model, mock_executor, mock_evaluator)
+        result = optimizer._optimize()
+        assert result.optimized_instruction in result.optimized_prompt
+
+
+class TestMIPROv2Run:
+    @patch("fair_forge.prompt_optimizer.mipro.mipro.InstructionProposer")
+    def test_run_returns_miprov2_result(self, mock_proposer_class, mock_model, mock_executor, mock_evaluator):
+        mock_proposer_class.return_value.propose.return_value = ["inst1", "inst2"]
+        result = MIPROv2Optimizer.run(
+            PromptOptimizerRetriever,
+            model=mock_model,
+            seed_prompt="seed",
+            objective="objective",
+            executor=mock_executor,
+            evaluator=mock_evaluator,
+            num_candidates=2,
+            num_trials=2,
+            num_demo_sets=2,
+        )
+        assert isinstance(result, MIPROv2Result)
+
+    @patch("fair_forge.prompt_optimizer.mipro.mipro.InstructionProposer")
+    def test_run_exposes_optimized_prompt(self, mock_proposer_class, mock_model, mock_executor, mock_evaluator):
+        mock_proposer_class.return_value.propose.return_value = ["inst1", "inst2"]
+        result = MIPROv2Optimizer.run(
+            PromptOptimizerRetriever,
+            model=mock_model,
+            seed_prompt="seed",
+            objective="objective",
+            executor=mock_executor,
+            evaluator=mock_evaluator,
+            num_candidates=2,
+            num_trials=2,
+            num_demo_sets=2,
+        )
+        assert isinstance(result.optimized_prompt, str)
+        assert len(result.optimized_prompt) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -171,6 +171,20 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "alquimia-client"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -185,13 +199,14 @@ wheels = [
 
 [[package]]
 name = "alquimia-fair-forge"
-version = "2.0.0b2"
+version = "2.0.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
     { name = "langchain" },
     { name = "langchain-core" },
     { name = "loguru" },
+    { name = "optuna" },
     { name = "pydantic" },
     { name = "scipy" },
     { name = "tqdm" },
@@ -209,6 +224,7 @@ all = [
     { name = "nltk" },
     { name = "numba" },
     { name = "numpy" },
+    { name = "optuna" },
     { name = "pandas" },
     { name = "python-dotenv" },
     { name = "scikit-learn" },
@@ -264,6 +280,9 @@ metrics = [
     { name = "torch" },
     { name = "umap-learn" },
 ]
+prompt-optimizer = [
+    { name = "optuna" },
+]
 regulatory = [
     { name = "accelerate" },
     { name = "torch" },
@@ -315,7 +334,7 @@ requires-dist = [
     { name = "alquimia-client", marker = "extra == 'generators-alquimia'", specifier = ">=0.1.0" },
     { name = "alquimia-client", marker = "extra == 'runners'", specifier = ">=0.1.0" },
     { name = "alquimia-fair-forge", extras = ["context", "conversational", "bestof", "agentic", "humanity", "toxicity", "bias", "regulatory"], marker = "extra == 'metrics'" },
-    { name = "alquimia-fair-forge", extras = ["metrics", "runners", "generators", "generators-alquimia", "explainability"], marker = "extra == 'all'" },
+    { name = "alquimia-fair-forge", extras = ["metrics", "runners", "generators", "generators-alquimia", "explainability", "prompt-optimizer"], marker = "extra == 'all'" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "hdbscan", marker = "extra == 'toxicity'", specifier = ">=0.8.41" },
     { name = "httpx", marker = "extra == 'runners'", specifier = ">=0.28.1" },
@@ -333,6 +352,8 @@ requires-dist = [
     { name = "numba", marker = "extra == 'toxicity'", specifier = ">=0.57.0" },
     { name = "numpy", marker = "extra == 'humanity'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'toxicity'", specifier = ">=1.24.0" },
+    { name = "optuna", specifier = ">=4.7.0" },
+    { name = "optuna", marker = "extra == 'prompt-optimizer'", specifier = ">=3.0.0" },
     { name = "pandas", marker = "extra == 'humanity'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'toxicity'", specifier = ">=2.0.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.0.0" },
@@ -361,7 +382,7 @@ requires-dist = [
     { name = "umap-learn", marker = "extra == 'toxicity'", specifier = ">=0.5.6,<0.6.0" },
     { name = "virtualenv", marker = "extra == 'dev'", specifier = ">=20.36.1" },
 ]
-provides-extras = ["context", "conversational", "bestof", "agentic", "humanity", "toxicity", "bias", "regulatory", "explainability", "metrics", "runners", "generators", "generators-alquimia", "all", "dev"]
+provides-extras = ["context", "conversational", "bestof", "agentic", "humanity", "toxicity", "bias", "regulatory", "explainability", "metrics", "runners", "prompt-optimizer", "generators", "generators-alquimia", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -791,6 +812,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
 ]
 
 [[package]]
@@ -1350,6 +1383,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/51/1664f6b78fc6ebbd98019a1fd730e83fa78f2db7058f72b1463d3612b8db/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2", size = 188267, upload-time = "2026-02-20T20:54:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
+    { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3a/efb2cf697fbccdf75b24e2c18025e7dfa54c4f31fab75c51d0fe79942cef/greenlet-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e692b2dae4cc7077cbb11b47d258533b48c8fde69a33d0d8a82e2fe8d8531d5", size = 230389, upload-time = "2026-02-20T20:17:18.772Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a1/65bbc059a43a7e2143ec4fc1f9e3f673e04f9c7b371a494a101422ac4fd5/greenlet-3.3.2-cp311-cp311-win_arm64.whl", hash = "sha256:02b0a8682aecd4d3c6c18edf52bc8e51eacdd75c8eac52a790a210b06aa295fd", size = 229645, upload-time = "2026-02-20T20:18:18.695Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/cc802e067d02af8b60b6771cea7d57e21ef5e6659912814babb42b864713/greenlet-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:34308836d8370bddadb41f5a7ce96879b72e2fdfb4e87729330c6ab52376409f", size = 231081, upload-time = "2026-02-20T20:17:28.121Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2e/fe7f36ff1982d6b10a60d5e0740c759259a7d6d2e1dc41da6d96de32fff6/greenlet-3.3.2-cp312-cp312-win_arm64.whl", hash = "sha256:d3a62fa76a32b462a97198e4c9e99afb9ab375115e74e9a83ce180e7a496f643", size = 230331, upload-time = "2026-02-20T20:17:23.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
+    { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ca/2101ca3d9223a1dc125140dbc063644dca76df6ff356531eb27bc267b446/greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492", size = 232034, upload-time = "2026-02-20T20:20:08.186Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/4a/ecf894e962a59dea60f04877eea0fd5724618da89f1867b28ee8b91e811f/greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71", size = 231437, upload-time = "2026-02-20T20:18:59.722Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
 ]
 
 [[package]]
@@ -2239,6 +2319,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
 ]
 
 [[package]]
@@ -3134,6 +3226,24 @@ version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
+name = "optuna"
+version = "4.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alembic" },
+    { name = "colorlog" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/b2/b5e12de7b4486556fe2257611b55dbabf30d0300bdb031831aa943ad20e4/optuna-4.7.0.tar.gz", hash = "sha256:d91817e2079825557bd2e97de2e8c9ae260bfc99b32712502aef8a5095b2d2c0", size = 479740, upload-time = "2026-01-19T05:45:52.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/d1/6c8a4fbb38a9e3565f5c36b871262a85ecab3da48120af036b1e4937a15c/optuna-4.7.0-py3-none-any.whl", hash = "sha256:e41ec84018cecc10eabf28143573b1f0bde0ba56dba8151631a590ecbebc1186", size = 413894, upload-time = "2026-01-19T05:45:50.815Z" },
 ]
 
 [[package]]
@@ -4881,6 +4991,59 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/73/b4a9737255583b5fa858e0bb8e116eb94b88c910164ed2ed719147bde3de/sqlalchemy-2.0.48.tar.gz", hash = "sha256:5ca74f37f3369b45e1f6b7b06afb182af1fd5dde009e4ffd831830d98cbe5fe7", size = 9886075, upload-time = "2026-03-02T15:28:51.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/6d/b8b78b5b80f3c3ab3f7fa90faa195ec3401f6d884b60221260fd4d51864c/sqlalchemy-2.0.48-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b4c575df7368b3b13e0cebf01d4679f9a28ed2ae6c1cd0b1d5beffb6b2007dc", size = 2157184, upload-time = "2026-03-02T15:38:28.161Z" },
+    { url = "https://files.pythonhosted.org/packages/21/4b/4f3d4a43743ab58b95b9ddf5580a265b593d017693df9e08bd55780af5bb/sqlalchemy-2.0.48-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e83e3f959aaa1c9df95c22c528096d94848a1bc819f5d0ebf7ee3df0ca63db6c", size = 3313555, upload-time = "2026-03-02T15:58:57.21Z" },
+    { url = "https://files.pythonhosted.org/packages/21/dd/3b7c53f1dbbf736fd27041aee68f8ac52226b610f914085b1652c2323442/sqlalchemy-2.0.48-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f7b7243850edd0b8b97043f04748f31de50cf426e939def5c16bedb540698f7", size = 3313057, upload-time = "2026-03-02T15:52:29.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cc/3e600a90ae64047f33313d7d32e5ad025417f09d2ded487e8284b5e21a15/sqlalchemy-2.0.48-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:82745b03b4043e04600a6b665cb98697c4339b24e34d74b0a2ac0a2488b6f94d", size = 3265431, upload-time = "2026-03-02T15:58:59.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/19/780138dacfe3f5024f4cf96e4005e91edf6653d53d3673be4844578faf1d/sqlalchemy-2.0.48-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5e088bf43f6ee6fec7dbf1ef7ff7774a616c236b5c0cb3e00662dd71a56b571", size = 3287646, upload-time = "2026-03-02T15:52:31.569Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fd/f32ced124f01a23151f4777e4c705f3a470adc7bd241d9f36a7c941a33bf/sqlalchemy-2.0.48-cp311-cp311-win32.whl", hash = "sha256:9c7d0a77e36b5f4b01ca398482230ab792061d243d715299b44a0b55c89fe617", size = 2116956, upload-time = "2026-03-02T15:46:54.535Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/dd767277f6feef12d05651538f280277e661698f617fa4d086cce6055416/sqlalchemy-2.0.48-cp311-cp311-win_amd64.whl", hash = "sha256:583849c743e0e3c9bb7446f5b5addeacedc168d657a69b418063dfdb2d90081c", size = 2141627, upload-time = "2026-03-02T15:46:55.849Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/91/a42ae716f8925e9659df2da21ba941f158686856107a61cc97a95e7647a3/sqlalchemy-2.0.48-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:348174f228b99f33ca1f773e85510e08927620caa59ffe7803b37170df30332b", size = 2155737, upload-time = "2026-03-02T15:49:13.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/52/f75f516a1f3888f027c1cfb5d22d4376f4b46236f2e8669dcb0cddc60275/sqlalchemy-2.0.48-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53667b5f668991e279d21f94ccfa6e45b4e3f4500e7591ae59a8012d0f010dcb", size = 3337020, upload-time = "2026-03-02T15:50:34.547Z" },
+    { url = "https://files.pythonhosted.org/packages/37/9a/0c28b6371e0cdcb14f8f1930778cb3123acfcbd2c95bb9cf6b4a2ba0cce3/sqlalchemy-2.0.48-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34634e196f620c7a61d18d5cf7dc841ca6daa7961aed75d532b7e58b309ac894", size = 3349983, upload-time = "2026-03-02T15:53:25.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/46/0aee8f3ff20b1dcbceb46ca2d87fcc3d48b407925a383ff668218509d132/sqlalchemy-2.0.48-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:546572a1793cc35857a2ffa1fe0e58571af1779bcc1ffa7c9fb0839885ed69a9", size = 3279690, upload-time = "2026-03-02T15:50:36.277Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/a957bc91293b49181350bfd55e6dfc6e30b7f7d83dc6792d72043274a390/sqlalchemy-2.0.48-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:07edba08061bc277bfdc772dd2a1a43978f5a45994dd3ede26391b405c15221e", size = 3314738, upload-time = "2026-03-02T15:53:27.519Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/44/1d257d9f9556661e7bdc83667cc414ba210acfc110c82938cb3611eea58f/sqlalchemy-2.0.48-cp312-cp312-win32.whl", hash = "sha256:908a3fa6908716f803b86896a09a2c4dde5f5ce2bb07aacc71ffebb57986ce99", size = 2115546, upload-time = "2026-03-02T15:54:31.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/af/c3c7e1f3a2b383155a16454df62ae8c62a30dd238e42e68c24cebebbfae6/sqlalchemy-2.0.48-cp312-cp312-win_amd64.whl", hash = "sha256:68549c403f79a8e25984376480959975212a670405e3913830614432b5daa07a", size = 2142484, upload-time = "2026-03-02T15:54:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/569dc8bf3cd375abc5907e82235923e986799f301cd79a903f784b996fca/sqlalchemy-2.0.48-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e3070c03701037aa418b55d36532ecb8f8446ed0135acb71c678dbdf12f5b6e4", size = 2152599, upload-time = "2026-03-02T15:49:14.41Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/f4e04a4bd5a24304f38cb0d4aa2ad4c0fb34999f8b884c656535e1b2b74c/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2645b7d8a738763b664a12a1542c89c940daa55196e8d73e55b169cc5c99f65f", size = 3278825, upload-time = "2026-03-02T15:50:38.269Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/88/cb59509e4668d8001818d7355d9995be90c321313078c912420603a7cb95/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b19151e76620a412c2ac1c6f977ab1b9fa7ad43140178345136456d5265b32ed", size = 3295200, upload-time = "2026-03-02T15:53:29.366Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/1609a4442aefd750ea2f32629559394ec92e89ac1d621a7f462b70f736ff/sqlalchemy-2.0.48-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5b193a7e29fd9fa56e502920dca47dffe60f97c863494946bd698c6058a55658", size = 3226876, upload-time = "2026-03-02T15:50:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c3/6ae2ab5ea2fa989fbac4e674de01224b7a9d744becaf59bb967d62e99bed/sqlalchemy-2.0.48-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:36ac4ddc3d33e852da9cb00ffb08cea62ca05c39711dc67062ca2bb1fae35fd8", size = 3265045, upload-time = "2026-03-02T15:53:31.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/82/ea4665d1bb98c50c19666e672f21b81356bd6077c4574e3d2bbb84541f53/sqlalchemy-2.0.48-cp313-cp313-win32.whl", hash = "sha256:389b984139278f97757ea9b08993e7b9d1142912e046ab7d82b3fbaeb0209131", size = 2113700, upload-time = "2026-03-02T15:54:35.825Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/2b/b9040bec58c58225f073f5b0c1870defe1940835549dafec680cbd58c3c3/sqlalchemy-2.0.48-cp313-cp313-win_amd64.whl", hash = "sha256:d612c976cbc2d17edfcc4c006874b764e85e990c29ce9bd411f926bbfb02b9a2", size = 2139487, upload-time = "2026-03-02T15:54:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/7b17bd50244b78a49d22cc63c969d71dc4de54567dc152a9b46f6fae40ce/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69f5bc24904d3bc3640961cddd2523e361257ef68585d6e364166dfbe8c78fae", size = 3558851, upload-time = "2026-03-02T15:57:48.607Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0d/213668e9aca61d370f7d2a6449ea4ec699747fac67d4bda1bb3d129025be/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd08b90d211c086181caed76931ecfa2bdfc83eea3cfccdb0f82abc6c4b876cb", size = 3525525, upload-time = "2026-03-02T16:04:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d7/a84edf412979e7d59c69b89a5871f90a49228360594680e667cb2c46a828/sqlalchemy-2.0.48-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1ccd42229aaac2df431562117ac7e667d702e8e44afdb6cf0e50fa3f18160f0b", size = 3466611, upload-time = "2026-03-02T15:57:50.759Z" },
+    { url = "https://files.pythonhosted.org/packages/86/55/42404ce5770f6be26a2b0607e7866c31b9a4176c819e9a7a5e0a055770be/sqlalchemy-2.0.48-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f0dcbc588cd5b725162c076eb9119342f6579c7f7f55057bb7e3c6ff27e13121", size = 3475812, upload-time = "2026-03-02T16:04:40.092Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ae/29b87775fadc43e627cf582fe3bda4d02e300f6b8f2747c764950d13784c/sqlalchemy-2.0.48-cp313-cp313t-win32.whl", hash = "sha256:9764014ef5e58aab76220c5664abb5d47d5bc858d9debf821e55cfdd0f128485", size = 2141335, upload-time = "2026-03-02T15:52:51.518Z" },
+    { url = "https://files.pythonhosted.org/packages/91/44/f39d063c90f2443e5b46ec4819abd3d8de653893aae92df42a5c4f5843de/sqlalchemy-2.0.48-cp313-cp313t-win_amd64.whl", hash = "sha256:e2f35b4cccd9ed286ad62e0a3c3ac21e06c02abc60e20aa51a3e305a30f5fa79", size = 2173095, upload-time = "2026-03-02T15:52:52.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b3/f437eaa1cf028bb3c927172c7272366393e73ccd104dcf5b6963f4ab5318/sqlalchemy-2.0.48-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e2d0d88686e3d35a76f3e15a34e8c12d73fc94c1dea1cd55782e695cc14086dd", size = 2154401, upload-time = "2026-03-02T15:49:17.24Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/1c/b3abdf0f402aa3f60f0df6ea53d92a162b458fca2321d8f1f00278506402/sqlalchemy-2.0.48-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49b7bddc1eebf011ea5ab722fdbe67a401caa34a350d278cc7733c0e88fecb1f", size = 3274528, upload-time = "2026-03-02T15:50:41.489Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/5e/327428a034407651a048f5e624361adf3f9fbac9d0fa98e981e9c6ff2f5e/sqlalchemy-2.0.48-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:426c5ca86415d9b8945c7073597e10de9644802e2ff502b8e1f11a7a2642856b", size = 3279523, upload-time = "2026-03-02T15:53:32.962Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ca/ece73c81a918add0965b76b868b7b5359e068380b90ef1656ee995940c02/sqlalchemy-2.0.48-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:288937433bd44e3990e7da2402fabc44a3c6c25d3704da066b85b89a85474ae0", size = 3224312, upload-time = "2026-03-02T15:50:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/88/11/fbaf1ae91fa4ee43f4fe79661cead6358644824419c26adb004941bdce7c/sqlalchemy-2.0.48-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8183dc57ae7d9edc1346e007e840a9f3d6aa7b7f165203a99e16f447150140d2", size = 3246304, upload-time = "2026-03-02T15:53:34.937Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5fb0deb13930b4f2f698c5541ae076c18981173e27dd00376dbaea7a9c82/sqlalchemy-2.0.48-cp314-cp314-win32.whl", hash = "sha256:1182437cb2d97988cfea04cf6cdc0b0bb9c74f4d56ec3d08b81e23d621a28cc6", size = 2116565, upload-time = "2026-03-02T15:54:38.321Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7e/e83615cb63f80047f18e61e31e8e32257d39458426c23006deeaf48f463b/sqlalchemy-2.0.48-cp314-cp314-win_amd64.whl", hash = "sha256:144921da96c08feb9e2b052c5c5c1d0d151a292c6135623c6b2c041f2a45f9e0", size = 2142205, upload-time = "2026-03-02T15:54:39.831Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e3/69d8711b3f2c5135e9cde5f063bc1605860f0b2c53086d40c04017eb1f77/sqlalchemy-2.0.48-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5aee45fd2c6c0f2b9cdddf48c48535e7471e42d6fb81adfde801da0bd5b93241", size = 3563519, upload-time = "2026-03-02T15:57:52.387Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4f/a7cce98facca73c149ea4578981594aaa5fd841e956834931de503359336/sqlalchemy-2.0.48-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7cddca31edf8b0653090cbb54562ca027c421c58ddde2c0685f49ff56a1690e0", size = 3528611, upload-time = "2026-03-02T16:04:42.097Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7d/5936c7a03a0b0cb0fa0cc425998821c6029756b0855a8f7ee70fba1de955/sqlalchemy-2.0.48-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7a936f1bb23d370b7c8cc079d5fce4c7d18da87a33c6744e51a93b0f9e97e9b3", size = 3472326, upload-time = "2026-03-02T15:57:54.423Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/33/cea7dfc31b52904efe3dcdc169eb4514078887dff1f5ae28a7f4c5d54b3c/sqlalchemy-2.0.48-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e004aa9248e8cb0a5f9b96d003ca7c1c0a5da8decd1066e7b53f59eb8ce7c62b", size = 3478453, upload-time = "2026-03-02T16:04:44.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/32107c4d13be077a9cae61e9ae49966a35dc4bf442a8852dd871db31f62e/sqlalchemy-2.0.48-cp314-cp314t-win32.whl", hash = "sha256:b8438ec5594980d405251451c5b7ea9aa58dda38eb7ac35fb7e4c696712ee24f", size = 2147209, upload-time = "2026-03-02T15:52:54.274Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d7/1e073da7a4bc645eb83c76067284a0374e643bc4be57f14cc6414656f92c/sqlalchemy-2.0.48-cp314-cp314t-win_amd64.whl", hash = "sha256:d854b3970067297f3a7fbd7a4683587134aa9b3877ee15aa29eea478dc68f933", size = 2182198, upload-time = "2026-03-02T15:52:55.606Z" },
+    { url = "https://files.pythonhosted.org/packages/46/2c/9664130905f03db57961b8980b05cab624afd114bf2be2576628a9f22da4/sqlalchemy-2.0.48-py3-none-any.whl", hash = "sha256:a66fe406437dd65cacd96a72689a3aaaecaebbcd62d81c5ac1c0fdbeac835096", size = 1940202, upload-time = "2026-03-02T15:52:43.285Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a new `prompt_optimizer` module with two optimization strategies: **GEPA** (Generative Evolutionary Prompt Adaptation) and **MIPROv2** (Multiprompt Instruction PRoposal Optimizer v2).
- Both optimizers follow the existing Fair Forge pattern (`Retriever` + `.run()`) and require only a seed prompt and a natural language objective to operate.
- Includes a shared `LLMEvaluator` for subjective criteria and support for custom deterministic evaluators.

## What was added

- `fair_forge/prompt_optimizer/` — base class, schemas, protocols, LLMEvaluator, GEPA and MIPROv2 implementations
- `examples/prompt_optimizer/` — Jupyter notebook examples with realistic datasets for each optimizer
- `tests/prompt_optimizer/` — 62 unit tests covering all components without live LLM calls
- `docs/prompt-optimizer/` — Mintlify documentation pages (overview, GEPA, MIPROv2) and updated navigation
- `optuna` added as a dependency for Bayesian search in MIPROv2

## How GEPA works

Evaluates the seed prompt against the dataset, identifies failing examples, generates improved candidates via an LLM that reads those failures, and picks the best. Repeats until the score stops improving or the iteration budget is exhausted.

## How MIPROv2 works

Two-phase process: first generates N instruction variants and M few-shot demo sets from the dataset. Then uses Bayesian Optimization (Optuna/TPE) to efficiently search through `(instruction, demo_set)` combinations and find the best-performing pair.

## Test plan

- [ ] Run `uv run pytest tests/prompt_optimizer/` — 62 tests, all passing
- [ ] Run GEPA notebook end to end with a Groq API key
- [ ] Run MIPROv2 notebook end to end with a Groq API key
- [ ] Verify docs render correctly with `mint dev` from the `docs/` directory