### PR TITLE
feat(metrics): add VisionSimilarity and VisionHallucination for VLM evaluation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -72,7 +72,8 @@
               "metrics/humanity",
               "metrics/best-of",
               "metrics/agentic",
-              "metrics/regulatory"
+              "metrics/regulatory",
+              "metrics/vision"
             ]
           },
           {

--- a/docs/metrics/vision.mdx
+++ b/docs/metrics/vision.mdx
@@ -5,7 +5,7 @@ description: Evaluate Vision Language Model (VLM) scene descriptions using seman
 
 # Vision Metrics
 
-The Vision metrics evaluate how accurately a Vision Language Model (VLM) describes scenes compared to human-annotated ground truth. They use **cosine similarity between sentence embeddings** (`all-mpnet-base-v2`) to compare free-text descriptions — no structured output required.
+The Vision metrics evaluate how accurately a Vision Language Model (VLM) describes scenes compared to human-annotated ground truth. They use a pluggable **SimilarityScorer** to compare free-text descriptions — no structured output required. The default scorer uses cosine similarity between sentence embeddings (`all-mpnet-base-v2`).
 
 Two metrics are available:
 
@@ -50,7 +50,7 @@ for r in results:
 |-----------|------|---------|-------------|
 | `retriever` | `Type[Retriever]` | — | Data source class |
 | `threshold` | `float` | `0.75` | Similarity cutoff for hallucination detection |
-| `model_name` | `str` | `"all-mpnet-base-v2"` | Sentence Transformer model for embeddings |
+| `scorer` | `SimilarityScorer` | `CosineSimilarity(SentenceTransformerEmbedder("all-mpnet-base-v2"))` | Strategy used to compare descriptions |
 | `verbose` | `bool` | `False` | Enable verbose logging |
 
 ### Threshold Guide
@@ -214,7 +214,15 @@ for r in results:
 
 <AccordionGroup>
   <Accordion title="Similarity scores are lower than expected">
-    The default model (`all-mpnet-base-v2`) is sensitive to domain-specific vocabulary. If your VLM uses technical terms not well represented in the model, try a domain-adapted Sentence Transformer via the `model_name` parameter.
+    The default model (`all-mpnet-base-v2`) is sensitive to domain-specific vocabulary. If your VLM uses technical terms not well represented in the model, pass a custom scorer with a domain-adapted embedder:
+
+    ```python
+    from fair_forge.embedders import SentenceTransformerEmbedder
+    from fair_forge.scorers import CosineSimilarity
+
+    scorer = CosineSimilarity(SentenceTransformerEmbedder(model="your-domain-model"))
+    results = VisionSimilarity.run(VLMRetriever, scorer=scorer, threshold=0.75)
+    ```
   </Accordion>
 
   <Accordion title="All frames flagged as hallucinations">

--- a/docs/metrics/vision.mdx
+++ b/docs/metrics/vision.mdx
@@ -1,0 +1,241 @@
+---
+title: Vision
+description: Evaluate Vision Language Model (VLM) scene descriptions using semantic similarity against human-annotated ground truth
+---
+
+# Vision Metrics
+
+The Vision metrics evaluate how accurately a Vision Language Model (VLM) describes scenes compared to human-annotated ground truth. They use **cosine similarity between sentence embeddings** (`all-mpnet-base-v2`) to compare free-text descriptions — no structured output required.
+
+Two metrics are available:
+
+| Metric | What it measures |
+|--------|-----------------|
+| **VisionSimilarity** | Average semantic closeness between VLM descriptions and ground truth across all frames |
+| **VisionHallucination** | How often the VLM describes something significantly different from what actually happened |
+
+## Installation
+
+```bash
+uv add "alquimia-fair-forge[vision]"
+```
+
+## Basic Usage
+
+<CodeGroup>
+```python VisionSimilarity
+from fair_forge.metrics.vision import VisionSimilarity
+from your_retriever import VLMRetriever
+
+results = VisionSimilarity.run(VLMRetriever, threshold=0.75)
+
+for r in results:
+    r.display()
+```
+
+```python VisionHallucination
+from fair_forge.metrics.vision import VisionHallucination
+from your_retriever import VLMRetriever
+
+results = VisionHallucination.run(VLMRetriever, threshold=0.75)
+
+for r in results:
+    r.display()
+```
+</CodeGroup>
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `retriever` | `Type[Retriever]` | — | Data source class |
+| `threshold` | `float` | `0.75` | Similarity cutoff for hallucination detection |
+| `model_name` | `str` | `"all-mpnet-base-v2"` | Sentence Transformer model for embeddings |
+| `verbose` | `bool` | `False` | Enable verbose logging |
+
+### Threshold Guide
+
+```python
+# Adjust based on your domain:
+THRESHOLD = 0.85  # Strict  — only near-identical descriptions pass
+THRESHOLD = 0.75  # Balanced — default, suitable for most use cases
+THRESHOLD = 0.60  # Lenient  — allows paraphrasing and partial descriptions
+```
+
+<Note>
+`VisionSimilarity` uses the threshold only for the `VisionHallucination` metric's flag logic. In `VisionSimilarity`, the threshold parameter is stored but does not affect the similarity scores — every frame is scored regardless.
+</Note>
+
+## Data Requirements
+
+Each `Batch` only needs two text fields:
+
+- `assistant` — free-text description produced by the VLM
+- `ground_truth_assistant` — human-annotated description of what actually happened
+
+All other `Batch` fields (`agentic`, `ground_truth_agentic`, etc.) are ignored.
+
+```python
+from fair_forge.core.retriever import Retriever
+from fair_forge.schemas.common import Dataset, Batch
+
+class VLMRetriever(Retriever):
+    def load_dataset(self) -> list[Dataset]:
+        return [
+            Dataset(
+                session_id="cam-entrance-01",
+                assistant_id="argos-gpt4o",
+                language="english",
+                context="Security camera monitoring the main building entrance.",
+                conversation=[
+                    Batch(
+                        qa_id="frame_001",
+                        query="Describe what you observe in this frame.",
+                        assistant="A person is lying motionless on the floor near the entrance.",
+                        ground_truth_assistant="A person fell near the entrance and requires assistance.",
+                    ),
+                    Batch(
+                        qa_id="frame_002",
+                        query="Describe what you observe in this frame.",
+                        assistant="The entrance area appears clear. No anomalies detected.",
+                        ground_truth_assistant="An unauthorized person is tailgating through the entrance.",
+                    ),
+                ],
+            )
+        ]
+```
+
+<Note>
+Each `Dataset` represents one camera session. Multiple sessions (e.g. different cameras) are returned as separate items in the list — each produces its own metric result.
+</Note>
+
+## Output Schema
+
+### VisionSimilarityMetric
+
+```python
+class VisionSimilarityMetric(BaseMetric):
+    session_id: str                              # Camera / session identifier
+    assistant_id: str                            # VLM identifier
+    mean_similarity: float                       # Average cosine similarity (0.0–1.0)
+    min_similarity: float                        # Lowest similarity frame
+    max_similarity: float                        # Highest similarity frame
+    summary: str                                 # Human-readable summary
+    interactions: list[VisionSimilarityInteraction]
+
+class VisionSimilarityInteraction(BaseModel):
+    qa_id: str                                   # Frame identifier
+    similarity_score: float                      # Cosine similarity for this frame
+```
+
+### VisionHallucinationMetric
+
+```python
+class VisionHallucinationMetric(BaseMetric):
+    session_id: str                              # Camera / session identifier
+    assistant_id: str                            # VLM identifier
+    hallucination_rate: float                    # n_hallucinations / n_frames
+    n_hallucinations: int                        # Frames below threshold
+    n_frames: int                                # Total frames evaluated
+    threshold: float                             # Threshold used for this run
+    summary: str                                 # Human-readable summary
+    interactions: list[VisionHallucinationInteraction]
+
+class VisionHallucinationInteraction(BaseModel):
+    qa_id: str                                   # Frame identifier
+    similarity_score: float                      # Cosine similarity for this frame
+    is_hallucination: bool                       # True if similarity < threshold
+```
+
+### display()
+
+Both metric types expose a `display()` method for quick inspection:
+
+```python
+results = VisionHallucination.run(VLMRetriever, threshold=0.75)
+
+for r in results:
+    r.display()
+
+# Output:
+# Session: cam-entrance-01  |  Assistant: argos-gpt4o
+# The model hallucinated in 1 of 2 frames (50%). A frame is considered a
+# hallucination when similarity with the ground truth falls below 0.75.
+#
+#   frame_001  similarity=0.89  ok
+#   frame_002  similarity=0.17  HALLUCINATION
+```
+
+## Interpretation
+
+### VisionSimilarity Scores
+
+| Score | Interpretation |
+|-------|---------------|
+| **0.90–1.00** | Near-identical descriptions — VLM is highly accurate |
+| **0.75–0.89** | Semantically close — minor wording differences |
+| **0.50–0.74** | Partial match — key details missing or altered |
+| **< 0.50** | Low similarity — VLM description diverges significantly |
+
+### VisionHallucination Rate
+
+| Rate | Interpretation |
+|------|---------------|
+| **< 10%** | ✅ Reliable — VLM describes scenes accurately |
+| **10–30%** | ⚠️ Review needed — some frames are missed or fabricated |
+| **> 30%** | ❌ Unreliable — VLM frequently hallucinates scene content |
+
+## Best Practices
+
+<AccordionGroup>
+  <Accordion title="Choose qa_id as a timestamp or frame ID">
+    Use a meaningful `qa_id` such as `"2026-03-17T14:00:00Z"` or `"cam1_frame_0042"` so results are traceable back to the original footage.
+  </Accordion>
+
+  <Accordion title="Tune the threshold per domain">
+    Security surveillance descriptions tend to be terse and factual — a threshold of `0.75` works well. For rich narrative descriptions (e.g. accessibility assistance), consider lowering to `0.65` to allow more paraphrasing.
+  </Accordion>
+
+  <Accordion title="Run both metrics together">
+    `VisionSimilarity` tells you the average quality across all frames. `VisionHallucination` tells you which specific frames are problematic. Run both to get a complete picture.
+
+    ```python
+    similarity = VisionSimilarity.run(VLMRetriever, threshold=THRESHOLD)
+    hallucination = VisionHallucination.run(VLMRetriever, threshold=THRESHOLD)
+    ```
+  </Accordion>
+
+  <Accordion title="Segment by session for per-camera analysis">
+    Each `Dataset` maps to one session result. Use `session_id` to identify individual cameras, shifts, or recording periods and compare performance across them.
+  </Accordion>
+</AccordionGroup>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Similarity scores are lower than expected">
+    The default model (`all-mpnet-base-v2`) is sensitive to domain-specific vocabulary. If your VLM uses technical terms not well represented in the model, try a domain-adapted Sentence Transformer via the `model_name` parameter.
+  </Accordion>
+
+  <Accordion title="All frames flagged as hallucinations">
+    Your threshold may be too strict for the description style. Print the raw similarity scores from `VisionSimilarity` first to calibrate before running `VisionHallucination`.
+  </Accordion>
+
+  <Accordion title="Model download is slow on first run">
+    `all-mpnet-base-v2` (~420 MB) is downloaded from HuggingFace on the first run and cached locally. Subsequent runs use the cache.
+  </Accordion>
+</AccordionGroup>
+
+## Next Steps
+
+<CardGroup cols={3}>
+  <Card title="Agentic Metric" icon="robot" href="/metrics/agentic">
+    Evaluate tool use and multi-step reasoning in AI agents
+  </Card>
+  <Card title="Context Metric" icon="book-open" href="/metrics/context">
+    Measure how well responses align with a given context
+  </Card>
+  <Card title="AWS Lambda" icon="aws" href="/examples/aws-lambda">
+    Deploy Vision metrics as a serverless function
+  </Card>
+</CardGroup>

--- a/examples/vision/jupyter/vision.ipynb
+++ b/examples/vision/jupyter/vision.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Vision Metrics\n",
+    "\n",
+    "Evaluate a Vision Language Model (VLM) using two metrics based on semantic similarity between the model's description and the human ground truth.\n",
+    "\n",
+    "| Metric | What it tells you |\n",
+    "|--------|-------------------|\n",
+    "| **VisionSimilarity** | How semantically close the VLM descriptions are to the ground truth on average. A score of 1.0 means identical meaning; 0.0 means completely unrelated. |\n",
+    "| **VisionHallucination** | How often the VLM describes something significantly different from what actually happened. A frame is a hallucination when similarity falls below `threshold`. |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install alquimia-fair-forge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\ericf\\Desktop\\Alquimia\\fair-forge\\.venv\\Lib\\site-packages\\requests\\__init__.py:86: RequestsDependencyWarning: Unable to find acceptable character detection dependency (chardet or charset_normalizer).\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "from fair_forge.metrics.vision import VisionSimilarity, VisionHallucination\n",
+    "\n",
+    "logging.getLogger('httpx').disabled = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-header",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Implementá un `Retriever` que cargue tu dataset de evaluación.\n",
+    "\n",
+    "Cada `Batch` necesita solo dos campos de texto:\n",
+    "- `assistant` — descripción libre del VLM sobre el frame\n",
+    "- `ground_truth_assistant` — descripción humana de lo que realmente ocurrió\n",
+    "\n",
+    "El `threshold` (por defecto `0.75`) define a partir de qué similitud una descripción se considera hallucination. Ajustalo según tu dominio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "from fair_forge import Retriever\n",
+    "from fair_forge.schemas import Dataset\n",
+    "\n",
+    "\n",
+    "class VLMRetriever(Retriever):\n",
+    "    def load_dataset(self) -> list[Dataset]:\n",
+    "        with open(Path('dataset.json'), encoding='utf-8') as f:\n",
+    "            return [Dataset.model_validate(item) for item in json.load(f)]\n",
+    "\n",
+    "\n",
+    "# dataset.json — estructura de cada evento:\n",
+    "#\n",
+    "# {\n",
+    "#   \"session_id\": \"cam-lobby-01\",\n",
+    "#   \"assistant_id\": \"argos-gpt4o\",\n",
+    "#   \"language\": \"english\",\n",
+    "#   \"context\": \"Lobby entrance camera\",\n",
+    "#   \"conversation\": [\n",
+    "#     {\n",
+    "#       \"qa_id\": \"2026-03-13T14:00:00Z\",\n",
+    "#       \"query\": \"Describe what you observe in this frame.\",\n",
+    "#       \"assistant\": \"A person is lying on the floor near the entrance.\",\n",
+    "#       \"ground_truth_assistant\": \"A person fell near the entrance.\"\n",
+    "#     }\n",
+    "#   ]\n",
+    "# }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fpr-header",
+   "metadata": {},
+   "source": [
+    "## Vision Similarity\n",
+    "\n",
+    "How accurately does the VLM describe scenes compared to the human ground truth?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fpr",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-16 17:28:10,395 - sentence_transformers.SentenceTransformer - INFO - Use pytorch device_name: cpu\n",
+      "2026-03-16 17:28:10,395 - sentence_transformers.SentenceTransformer - INFO - Load pretrained SentenceTransformer: all-mpnet-base-v2\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ce36a81c1b8e45b5baccea375ce36534",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "cam-entrance-01:   0%|          | 0/5 [00:00<?, ?frame/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "869700e1ee30445f8a51cbdb3bf9d233",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "cam-parking-02:   0%|          | 0/4 [00:00<?, ?frame/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The model's descriptions have an average similarity of 59% with the ground truth (min: 28%, max: 89%) across 5 frames.\n",
+      "\n",
+      "  frame_001  similarity=0.89\n",
+      "  frame_002  similarity=0.70\n",
+      "  frame_003  similarity=0.43\n",
+      "  frame_004  similarity=0.67\n",
+      "  frame_005  similarity=0.28\n",
+      "The model's descriptions have an average similarity of 74% with the ground truth (min: 33%, max: 90%) across 4 frames.\n",
+      "\n",
+      "  frame_001  similarity=0.90\n",
+      "  frame_002  similarity=0.88\n",
+      "  frame_003  similarity=0.33\n",
+      "  frame_004  similarity=0.86\n"
+     ]
+    }
+   ],
+   "source": [
+    "similarity_results = VisionSimilarity.run(VLMRetriever, threshold=0.75)\n",
+    "\n",
+    "for r in similarity_results:\n",
+    "    print(r.summary)\n",
+    "    print()\n",
+    "    for i in r.interactions:\n",
+    "        print(f'  {i.qa_id}  similarity={i.similarity_score:.2f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "precision-header",
+   "metadata": {},
+   "source": [
+    "## Vision Hallucination\n",
+    "\n",
+    "How often does the VLM describe something significantly different from what actually happened?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "precision",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-16 17:28:17,017 - sentence_transformers.SentenceTransformer - INFO - Use pytorch device_name: cpu\n",
+      "2026-03-16 17:28:17,018 - sentence_transformers.SentenceTransformer - INFO - Load pretrained SentenceTransformer: all-mpnet-base-v2\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df55edf2edb94a4d98a8918acca01d40",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "cam-entrance-01:   0%|          | 0/5 [00:00<?, ?frame/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1c16bbdd49124d28849c90f0ea599d7f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "cam-parking-02:   0%|          | 0/4 [00:00<?, ?frame/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The model hallucinated in 4 of 5 frames (80%). A frame is considered a hallucination when similarity with the ground truth falls below 0.75.\n",
+      "\n",
+      "  frame_001  similarity=0.89  ok\n",
+      "  frame_002  similarity=0.70  HALLUCINATION\n",
+      "  frame_003  similarity=0.43  HALLUCINATION\n",
+      "  frame_004  similarity=0.67  HALLUCINATION\n",
+      "  frame_005  similarity=0.28  HALLUCINATION\n",
+      "The model hallucinated in 1 of 4 frames (25%). A frame is considered a hallucination when similarity with the ground truth falls below 0.75.\n",
+      "\n",
+      "  frame_001  similarity=0.90  ok\n",
+      "  frame_002  similarity=0.88  ok\n",
+      "  frame_003  similarity=0.33  HALLUCINATION\n",
+      "  frame_004  similarity=0.86  ok\n"
+     ]
+    }
+   ],
+   "source": [
+    "hallucination_results = VisionHallucination.run(VLMRetriever, threshold=0.75)\n",
+    "\n",
+    "for r in hallucination_results:\n",
+    "    print(r.summary)\n",
+    "    print()\n",
+    "    for i in r.interactions:\n",
+    "        label = 'HALLUCINATION' if i.is_hallucination else 'ok'\n",
+    "        print(f'  {i.qa_id}  similarity={i.similarity_score:.2f}  {label}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/vision/jupyter/vision.ipynb
+++ b/examples/vision/jupyter/vision.ipynb
@@ -20,7 +20,22 @@
    "execution_count": null,
    "id": "install",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Defaulting to user installation because normal site-packages is not writeable\n",
+      "\u001b[31mERROR: Ignored the following versions that require a different python version: 1.0.0 Requires-Python >=3.11; 1.1.0 Requires-Python >=3.11; 1.2.0 Requires-Python >=3.11; 1.2.0b1 Requires-Python >=3.11; 1.2.0b2 Requires-Python >=3.11; 1.2.0b3 Requires-Python >=3.11; 1.2.0b4 Requires-Python >=3.11; 1.2.0b5 Requires-Python >=3.11; 1.2.0b6 Requires-Python >=3.11; 1.2.0b7 Requires-Python >=3.11; 1.3.0b1 Requires-Python >=3.11; 2.0.0 Requires-Python >=3.11; 2.0.0b1 Requires-Python >=3.11; 2.0.0b2 Requires-Python >=3.11; 2.0.0b3 Requires-Python >=3.11; 3.0.0b1 Requires-Python >=3.11\u001b[0m\u001b[31m\n",
+      "\u001b[0m\u001b[31mERROR: Could not find a version that satisfies the requirement alquimia-fair-forge (from versions: none)\u001b[0m\u001b[31m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.3\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.0.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49m/Library/Developer/CommandLineTools/usr/bin/python3 -m pip install --upgrade pip\u001b[0m\n",
+      "\u001b[31mERROR: No matching distribution found for alquimia-fair-forge\u001b[0m\u001b[31m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
    "source": [
     "!pip install alquimia-fair-forge"
    ]
@@ -30,16 +45,7 @@
    "execution_count": 1,
    "id": "imports",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\ericf\\Desktop\\Alquimia\\fair-forge\\.venv\\Lib\\site-packages\\requests\\__init__.py:86: RequestsDependencyWarning: Unable to find acceptable character detection dependency (chardet or charset_normalizer).\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import logging\n",
     "from fair_forge.metrics.vision import VisionSimilarity, VisionHallucination\n",
@@ -51,54 +57,15 @@
    "cell_type": "markdown",
    "id": "setup-header",
    "metadata": {},
-   "source": [
-    "## Setup\n",
-    "\n",
-    "Implementá un `Retriever` que cargue tu dataset de evaluación.\n",
-    "\n",
-    "Cada `Batch` necesita solo dos campos de texto:\n",
-    "- `assistant` — descripción libre del VLM sobre el frame\n",
-    "- `ground_truth_assistant` — descripción humana de lo que realmente ocurrió\n",
-    "\n",
-    "El `threshold` (por defecto `0.75`) define a partir de qué similitud una descripción se considera hallucination. Ajustalo según tu dominio."
-   ]
+   "source": "## Setup\n\nImplement a `Retriever` that loads your evaluation dataset.\n\nEach `Batch` only needs two text fields:\n- `assistant` — free-text description produced by the VLM\n- `ground_truth_assistant` — human-annotated description of what actually happened"
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "setup",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import json\n",
-    "from pathlib import Path\n",
-    "from fair_forge import Retriever\n",
-    "from fair_forge.schemas import Dataset\n",
-    "\n",
-    "\n",
-    "class VLMRetriever(Retriever):\n",
-    "    def load_dataset(self) -> list[Dataset]:\n",
-    "        with open(Path('dataset.json'), encoding='utf-8') as f:\n",
-    "            return [Dataset.model_validate(item) for item in json.load(f)]\n",
-    "\n",
-    "\n",
-    "# dataset.json — estructura de cada evento:\n",
-    "#\n",
-    "# {\n",
-    "#   \"session_id\": \"cam-lobby-01\",\n",
-    "#   \"assistant_id\": \"argos-gpt4o\",\n",
-    "#   \"language\": \"english\",\n",
-    "#   \"context\": \"Lobby entrance camera\",\n",
-    "#   \"conversation\": [\n",
-    "#     {\n",
-    "#       \"qa_id\": \"2026-03-13T14:00:00Z\",\n",
-    "#       \"query\": \"Describe what you observe in this frame.\",\n",
-    "#       \"assistant\": \"A person is lying on the floor near the entrance.\",\n",
-    "#       \"ground_truth_assistant\": \"A person fell near the entrance.\"\n",
-    "#     }\n",
-    "#   ]\n",
-    "# }"
-   ]
+   "source": "import json\nfrom pathlib import Path\nfrom fair_forge import Retriever\nfrom fair_forge.schemas import Dataset\n\n\nclass VLMRetriever(Retriever):\n    def load_dataset(self) -> list[Dataset]:\n        with open(Path('dataset.json'), encoding='utf-8') as f:\n            return [Dataset.model_validate(item) for item in json.load(f)]\n\n\n# Threshold — frames with similarity below this value are flagged as hallucinations.\n# Adjust based on your domain:\n#   0.85+ → strict (only near-identical descriptions pass)\n#   0.75  → balanced (default)\n#   0.60  → lenient (allows paraphrasing and partial descriptions)\nTHRESHOLD = 0.75"
   },
   {
    "cell_type": "markdown",
@@ -112,75 +79,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "fpr",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-03-16 17:28:10,395 - sentence_transformers.SentenceTransformer - INFO - Use pytorch device_name: cpu\n",
-      "2026-03-16 17:28:10,395 - sentence_transformers.SentenceTransformer - INFO - Load pretrained SentenceTransformer: all-mpnet-base-v2\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ce36a81c1b8e45b5baccea375ce36534",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "cam-entrance-01:   0%|          | 0/5 [00:00<?, ?frame/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "869700e1ee30445f8a51cbdb3bf9d233",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "cam-parking-02:   0%|          | 0/4 [00:00<?, ?frame/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The model's descriptions have an average similarity of 59% with the ground truth (min: 28%, max: 89%) across 5 frames.\n",
-      "\n",
-      "  frame_001  similarity=0.89\n",
-      "  frame_002  similarity=0.70\n",
-      "  frame_003  similarity=0.43\n",
-      "  frame_004  similarity=0.67\n",
-      "  frame_005  similarity=0.28\n",
-      "The model's descriptions have an average similarity of 74% with the ground truth (min: 33%, max: 90%) across 4 frames.\n",
-      "\n",
-      "  frame_001  similarity=0.90\n",
-      "  frame_002  similarity=0.88\n",
-      "  frame_003  similarity=0.33\n",
-      "  frame_004  similarity=0.86\n"
-     ]
-    }
-   ],
-   "source": [
-    "similarity_results = VisionSimilarity.run(VLMRetriever, threshold=0.75)\n",
-    "\n",
-    "for r in similarity_results:\n",
-    "    print(r.summary)\n",
-    "    print()\n",
-    "    for i in r.interactions:\n",
-    "        print(f'  {i.qa_id}  similarity={i.similarity_score:.2f}')"
-   ]
+   "outputs": [],
+   "source": "similarity_results = VisionSimilarity.run(VLMRetriever, threshold=THRESHOLD)\n\nfor r in similarity_results:\n    r.display()"
   },
   {
    "cell_type": "markdown",
@@ -194,81 +97,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "precision",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-03-16 17:28:17,017 - sentence_transformers.SentenceTransformer - INFO - Use pytorch device_name: cpu\n",
-      "2026-03-16 17:28:17,018 - sentence_transformers.SentenceTransformer - INFO - Load pretrained SentenceTransformer: all-mpnet-base-v2\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df55edf2edb94a4d98a8918acca01d40",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "cam-entrance-01:   0%|          | 0/5 [00:00<?, ?frame/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1c16bbdd49124d28849c90f0ea599d7f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "cam-parking-02:   0%|          | 0/4 [00:00<?, ?frame/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The model hallucinated in 4 of 5 frames (80%). A frame is considered a hallucination when similarity with the ground truth falls below 0.75.\n",
-      "\n",
-      "  frame_001  similarity=0.89  ok\n",
-      "  frame_002  similarity=0.70  HALLUCINATION\n",
-      "  frame_003  similarity=0.43  HALLUCINATION\n",
-      "  frame_004  similarity=0.67  HALLUCINATION\n",
-      "  frame_005  similarity=0.28  HALLUCINATION\n",
-      "The model hallucinated in 1 of 4 frames (25%). A frame is considered a hallucination when similarity with the ground truth falls below 0.75.\n",
-      "\n",
-      "  frame_001  similarity=0.90  ok\n",
-      "  frame_002  similarity=0.88  ok\n",
-      "  frame_003  similarity=0.33  HALLUCINATION\n",
-      "  frame_004  similarity=0.86  ok\n"
-     ]
-    }
-   ],
-   "source": [
-    "hallucination_results = VisionHallucination.run(VLMRetriever, threshold=0.75)\n",
-    "\n",
-    "for r in hallucination_results:\n",
-    "    print(r.summary)\n",
-    "    print()\n",
-    "    for i in r.interactions:\n",
-    "        label = 'HALLUCINATION' if i.is_hallucination else 'ok'\n",
-    "        print(f'  {i.qa_id}  similarity={i.similarity_score:.2f}  {label}')"
-   ]
+   "outputs": [],
+   "source": "hallucination_results = VisionHallucination.run(VLMRetriever, threshold=THRESHOLD)\n\nfor r in hallucination_results:\n    r.display()"
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "alquimia-fair-forge",
    "language": "python",
    "name": "python3"
   },
@@ -282,7 +120,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,

--- a/examples/vision/jupyter/vision.ipynb
+++ b/examples/vision/jupyter/vision.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 6,
    "id": "imports",
    "metadata": {},
    "outputs": [],
@@ -57,15 +57,42 @@
    "cell_type": "markdown",
    "id": "setup-header",
    "metadata": {},
-   "source": "## Setup\n\nImplement a `Retriever` that loads your evaluation dataset.\n\nEach `Batch` only needs two text fields:\n- `assistant` — free-text description produced by the VLM\n- `ground_truth_assistant` — human-annotated description of what actually happened"
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Implement a `Retriever` that loads your evaluation dataset.\n",
+    "\n",
+    "Each `Batch` only needs two text fields:\n",
+    "- `assistant` — free-text description produced by the VLM\n",
+    "- `ground_truth_assistant` — human-annotated description of what actually happened"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "setup",
    "metadata": {},
    "outputs": [],
-   "source": "import json\nfrom pathlib import Path\nfrom fair_forge import Retriever\nfrom fair_forge.schemas import Dataset\n\n\nclass VLMRetriever(Retriever):\n    def load_dataset(self) -> list[Dataset]:\n        with open(Path('dataset.json'), encoding='utf-8') as f:\n            return [Dataset.model_validate(item) for item in json.load(f)]\n\n\n# Threshold — frames with similarity below this value are flagged as hallucinations.\n# Adjust based on your domain:\n#   0.85+ → strict (only near-identical descriptions pass)\n#   0.75  → balanced (default)\n#   0.60  → lenient (allows paraphrasing and partial descriptions)\nTHRESHOLD = 0.75"
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "from fair_forge import Retriever\n",
+    "from fair_forge.schemas import Dataset\n",
+    "\n",
+    "\n",
+    "class VLMRetriever(Retriever):\n",
+    "    def load_dataset(self) -> list[Dataset]:\n",
+    "        with open(Path('dataset.json'), encoding='utf-8') as f:\n",
+    "            return [Dataset.model_validate(item) for item in json.load(f)]\n",
+    "\n",
+    "\n",
+    "# Threshold — frames with similarity below this value are flagged as hallucinations.\n",
+    "# Adjust based on your domain:\n",
+    "#   0.85+ → strict (only near-identical descriptions pass)\n",
+    "#   0.75  → balanced (default)\n",
+    "#   0.60  → lenient (allows paraphrasing and partial descriptions)\n",
+    "THRESHOLD = 0.75"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -79,11 +106,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "fpr",
    "metadata": {},
-   "outputs": [],
-   "source": "similarity_results = VisionSimilarity.run(VLMRetriever, threshold=THRESHOLD)\n\nfor r in similarity_results:\n    r.display()"
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-18 11:36:58,864 - sentence_transformers.SentenceTransformer - INFO - Use pytorch device_name: mps\n",
+      "2026-03-18 11:36:58,865 - sentence_transformers.SentenceTransformer - INFO - Load pretrained SentenceTransformer: all-mpnet-base-v2\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d7dfa26626fe431b8f9b6a2aa89b4048",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "cam-entrance-01:   0%|          | 0/5 [00:00<?, ?frame/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "26e5cb4ae2a34fac8900fc9b024e166f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "cam-parking-02:   0%|          | 0/4 [00:00<?, ?frame/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Session: cam-entrance-01  |  Assistant: argos-gpt4o\n",
+      "The model's descriptions have an average similarity of 62% with the ground truth (min: 17%, max: 91%) across 5 frames.\n",
+      "\n",
+      "  frame_001  similarity=0.85\n",
+      "  frame_002  similarity=0.91\n",
+      "  frame_003  similarity=0.17\n",
+      "  frame_004  similarity=0.80\n",
+      "  frame_005  similarity=0.35\n",
+      "\n",
+      "Session: cam-parking-02  |  Assistant: argos-gpt4o\n",
+      "The model's descriptions have an average similarity of 73% with the ground truth (min: 23%, max: 91%) across 4 frames.\n",
+      "\n",
+      "  frame_001  similarity=0.91\n",
+      "  frame_002  similarity=0.90\n",
+      "  frame_003  similarity=0.23\n",
+      "  frame_004  similarity=0.86\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "similarity_results = VisionSimilarity.run(VLMRetriever, threshold=THRESHOLD)\n",
+    "\n",
+    "for r in similarity_results:\n",
+    "    r.display()"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -97,11 +189,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "precision",
    "metadata": {},
-   "outputs": [],
-   "source": "hallucination_results = VisionHallucination.run(VLMRetriever, threshold=THRESHOLD)\n\nfor r in hallucination_results:\n    r.display()"
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-03-18 11:37:04,328 - sentence_transformers.SentenceTransformer - INFO - Use pytorch device_name: mps\n",
+      "2026-03-18 11:37:04,330 - sentence_transformers.SentenceTransformer - INFO - Load pretrained SentenceTransformer: all-mpnet-base-v2\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "21063eb7399c4ecb85d22b042364afff",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "cam-entrance-01:   0%|          | 0/5 [00:00<?, ?frame/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9445cfaf539d487f87f5917d7ac60c8b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "cam-parking-02:   0%|          | 0/4 [00:00<?, ?frame/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Session: cam-entrance-01  |  Assistant: argos-gpt4o\n",
+      "The model hallucinated in 2 of 5 frames (40%). A frame is considered a hallucination when similarity with the ground truth falls below 0.75.\n",
+      "\n",
+      "  frame_001  similarity=0.85  ok\n",
+      "  frame_002  similarity=0.91  ok\n",
+      "  frame_003  similarity=0.17  HALLUCINATION\n",
+      "  frame_004  similarity=0.80  ok\n",
+      "  frame_005  similarity=0.35  HALLUCINATION\n",
+      "\n",
+      "Session: cam-parking-02  |  Assistant: argos-gpt4o\n",
+      "The model hallucinated in 1 of 4 frames (25%). A frame is considered a hallucination when similarity with the ground truth falls below 0.75.\n",
+      "\n",
+      "  frame_001  similarity=0.91  ok\n",
+      "  frame_002  similarity=0.90  ok\n",
+      "  frame_003  similarity=0.23  HALLUCINATION\n",
+      "  frame_004  similarity=0.86  ok\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "hallucination_results = VisionHallucination.run(VLMRetriever, threshold=THRESHOLD)\n",
+    "\n",
+    "for r in hallucination_results:\n",
+    "    r.display()"
+   ]
   }
  ],
  "metadata": {

--- a/fair_forge/core/__init__.py
+++ b/fair_forge/core/__init__.py
@@ -22,6 +22,7 @@ from .loader import ToxicityLoader
 from .reranker import Reranker
 from .retriever import Retriever
 from .sentiment import SentimentAnalyzer
+from .similarity_scorer import SimilarityScorer
 
 __all__ = [
     "BaseGroupExtractor",
@@ -36,6 +37,7 @@ __all__ = [
     "Retriever",
     "RetrieverError",
     "SentimentAnalyzer",
+    "SimilarityScorer",
     "StatisticalModeError",
     "ToxicityLoader",
 ]

--- a/fair_forge/core/similarity_scorer.py
+++ b/fair_forge/core/similarity_scorer.py
@@ -1,0 +1,12 @@
+"""SimilarityScorer abstract base class."""
+
+from abc import ABC, abstractmethod
+
+
+class SimilarityScorer(ABC):
+    """Abstract interface for computing semantic similarity between two texts."""
+
+    @abstractmethod
+    def calculate(self, assistant: str, ground_truth: str) -> float:
+        """Return a similarity score between 0.0 and 1.0."""
+        ...

--- a/fair_forge/metrics/__init__.py
+++ b/fair_forge/metrics/__init__.py
@@ -9,6 +9,7 @@ Import metrics directly from their modules:
     from fair_forge.metrics.best_of import BestOf
     from fair_forge.metrics.agentic import Agentic
     from fair_forge.metrics.regulatory import Regulatory
+    from fair_forge.metrics.vision import VisionHallucination, VisionSimilarity
 """
 
 __all__ = [
@@ -20,4 +21,6 @@ __all__ = [
     "Humanity",
     "Regulatory",
     "Toxicity",
+    "VisionHallucination",
+    "VisionSimilarity",
 ]

--- a/fair_forge/metrics/vision.py
+++ b/fair_forge/metrics/vision.py
@@ -2,10 +2,9 @@
 
 from abc import abstractmethod
 
-import numpy as np
 from tqdm.auto import tqdm
 
-from fair_forge.core import FairForge, Retriever
+from fair_forge.core import FairForge, Retriever, SimilarityScorer
 from fair_forge.schemas import Batch
 from fair_forge.schemas.vision import (
     VisionHallucinationInteraction,
@@ -18,15 +17,18 @@ _DEFAULT_MODEL = "all-mpnet-base-v2"
 _DEFAULT_THRESHOLD = 0.75
 
 
-def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
-    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+def _default_scorer() -> SimilarityScorer:
+    from fair_forge.embedders import SentenceTransformerEmbedder
+    from fair_forge.scorers import CosineSimilarity
+
+    return CosineSimilarity(SentenceTransformerEmbedder(model=_DEFAULT_MODEL))
 
 
 class _VisionBase(FairForge):
     """Shared base for vision metrics.
 
     Compares VLM free-text descriptions against human ground truth
-    using cosine similarity between sentence embeddings.
+    using a pluggable SimilarityScorer.
 
     Expected Batch fields:
         assistant              — VLM free-text description of the scene
@@ -36,21 +38,14 @@ class _VisionBase(FairForge):
     def __init__(
         self,
         retriever: type[Retriever],
-        model_name: str = _DEFAULT_MODEL,
+        scorer: SimilarityScorer | None = None,
         threshold: float = _DEFAULT_THRESHOLD,
         **kwargs,
     ):
         super().__init__(retriever, **kwargs)
-        self._model_name = model_name
+        self._scorer = scorer if scorer is not None else _default_scorer()
         self._threshold = threshold
-        self._encoder = None
         self._session_data: dict[str, dict] = {}
-
-    def _get_encoder(self):
-        if self._encoder is None:
-            from sentence_transformers import SentenceTransformer
-            self._encoder = SentenceTransformer(self._model_name)
-        return self._encoder
 
     def batch(
         self,
@@ -63,13 +58,9 @@ class _VisionBase(FairForge):
         if session_id not in self._session_data:
             self._session_data[session_id] = {"assistant_id": assistant_id, "interactions": []}
 
-        encoder = self._get_encoder()
-        emb_a = encoder.encode([i.assistant for i in batch], show_progress_bar=False)
-        emb_b = encoder.encode([i.ground_truth_assistant for i in batch], show_progress_bar=False)
-
-        for interaction, a, b in tqdm(zip(batch, emb_a, emb_b), desc=session_id, unit="frame", total=len(batch)):
+        for interaction in tqdm(batch, desc=session_id, unit="frame"):
             self.logger.debug(f"QA ID: {interaction.qa_id}")
-            similarity = _cosine_similarity(a, b)
+            similarity = self._scorer.calculate(interaction.assistant, interaction.ground_truth_assistant)
             self._session_data[session_id]["interactions"].append(
                 {"qa_id": interaction.qa_id, "similarity_score": round(similarity, 4)}
             )
@@ -82,9 +73,9 @@ class _VisionBase(FairForge):
 class VisionSimilarity(_VisionBase):
     """Measures how accurately the VLM describes scenes compared to human ground truth.
 
-    Uses cosine similarity between sentence embeddings of the VLM description
-    and the human-annotated ground truth. A score of 1.0 means the descriptions
-    are semantically identical; 0.0 means they are completely unrelated.
+    Uses a SimilarityScorer to compare the VLM description against the human-annotated
+    ground truth. A score of 1.0 means the descriptions are semantically identical;
+    0.0 means they are completely unrelated.
     """
 
     def on_process_complete(self):
@@ -114,7 +105,7 @@ class VisionSimilarity(_VisionBase):
 class VisionHallucination(_VisionBase):
     """Measures how often the VLM describes scenes that differ significantly from reality.
 
-    A frame is considered a hallucination when the cosine similarity between the VLM
+    A frame is considered a hallucination when the similarity score between the VLM
     description and the ground truth falls below the configured threshold.
     """
 

--- a/fair_forge/metrics/vision.py
+++ b/fair_forge/metrics/vision.py
@@ -1,0 +1,151 @@
+"""Vision metrics: Similarity and Hallucination for VLM evaluation."""
+
+from abc import abstractmethod
+
+import numpy as np
+from tqdm.auto import tqdm
+
+from fair_forge.core import FairForge, Retriever
+from fair_forge.schemas import Batch
+from fair_forge.schemas.vision import (
+    VisionHallucinationInteraction,
+    VisionHallucinationMetric,
+    VisionSimilarityInteraction,
+    VisionSimilarityMetric,
+)
+
+_DEFAULT_MODEL = "all-mpnet-base-v2"
+_DEFAULT_THRESHOLD = 0.75
+
+
+def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+
+class _VisionBase(FairForge):
+    """Shared base for vision metrics.
+
+    Compares VLM free-text descriptions against human ground truth
+    using cosine similarity between sentence embeddings.
+
+    Expected Batch fields:
+        assistant              — VLM free-text description of the scene
+        ground_truth_assistant — human description of what actually happened
+    """
+
+    def __init__(
+        self,
+        retriever: type[Retriever],
+        model_name: str = _DEFAULT_MODEL,
+        threshold: float = _DEFAULT_THRESHOLD,
+        **kwargs,
+    ):
+        super().__init__(retriever, **kwargs)
+        self._model_name = model_name
+        self._threshold = threshold
+        self._encoder = None
+        self._session_data: dict[str, dict] = {}
+
+    def _get_encoder(self):
+        if self._encoder is None:
+            from sentence_transformers import SentenceTransformer
+            self._encoder = SentenceTransformer(self._model_name)
+        return self._encoder
+
+    def batch(
+        self,
+        session_id: str,
+        context: str,
+        assistant_id: str,
+        batch: list[Batch],
+        language: str | None = "english",
+    ):
+        if session_id not in self._session_data:
+            self._session_data[session_id] = {"assistant_id": assistant_id, "interactions": []}
+
+        encoder = self._get_encoder()
+        emb_a = encoder.encode([i.assistant for i in batch], show_progress_bar=False)
+        emb_b = encoder.encode([i.ground_truth_assistant for i in batch], show_progress_bar=False)
+
+        for interaction, a, b in tqdm(zip(batch, emb_a, emb_b), desc=session_id, unit="frame", total=len(batch)):
+            self.logger.debug(f"QA ID: {interaction.qa_id}")
+            similarity = _cosine_similarity(a, b)
+            self._session_data[session_id]["interactions"].append(
+                {"qa_id": interaction.qa_id, "similarity_score": round(similarity, 4)}
+            )
+
+    @abstractmethod
+    def on_process_complete(self):
+        raise NotImplementedError
+
+
+class VisionSimilarity(_VisionBase):
+    """Measures how accurately the VLM describes scenes compared to human ground truth.
+
+    Uses cosine similarity between sentence embeddings of the VLM description
+    and the human-annotated ground truth. A score of 1.0 means the descriptions
+    are semantically identical; 0.0 means they are completely unrelated.
+    """
+
+    def on_process_complete(self):
+        for session_id, data in self._session_data.items():
+            raw = data["interactions"]
+            scores = [i["similarity_score"] for i in raw]
+            mean = round(sum(scores) / len(scores), 4)
+            min_s = round(min(scores), 4)
+            max_s = round(max(scores), 4)
+            summary = (
+                f"The model's descriptions have an average similarity of {mean:.0%} with the ground truth "
+                f"(min: {min_s:.0%}, max: {max_s:.0%}) across {len(scores)} frames."
+            )
+            self.metrics.append(
+                VisionSimilarityMetric(
+                    session_id=session_id,
+                    assistant_id=data["assistant_id"],
+                    mean_similarity=mean,
+                    min_similarity=min_s,
+                    max_similarity=max_s,
+                    summary=summary,
+                    interactions=[VisionSimilarityInteraction(**i) for i in raw],
+                )
+            )
+
+
+class VisionHallucination(_VisionBase):
+    """Measures how often the VLM describes scenes that differ significantly from reality.
+
+    A frame is considered a hallucination when the cosine similarity between the VLM
+    description and the ground truth falls below the configured threshold.
+    """
+
+    def on_process_complete(self):
+        for session_id, data in self._session_data.items():
+            raw = data["interactions"]
+            n_frames = len(raw)
+            interactions = [
+                VisionHallucinationInteraction(
+                    qa_id=i["qa_id"],
+                    similarity_score=i["similarity_score"],
+                    is_hallucination=i["similarity_score"] < self._threshold,
+                )
+                for i in raw
+            ]
+            n_hallucinations = sum(1 for i in interactions if i.is_hallucination)
+            rate = round(n_hallucinations / n_frames, 4) if n_frames > 0 else 0.0
+            summary = (
+                f"The model hallucinated in {n_hallucinations} of {n_frames} frames "
+                f"({rate:.0%}). A frame is considered a hallucination when similarity "
+                f"with the ground truth falls below {self._threshold}."
+            )
+            self.metrics.append(
+                VisionHallucinationMetric(
+                    session_id=session_id,
+                    assistant_id=data["assistant_id"],
+                    hallucination_rate=rate,
+                    n_hallucinations=n_hallucinations,
+                    n_frames=n_frames,
+                    threshold=self._threshold,
+                    summary=summary,
+                    interactions=interactions,
+                )
+            )

--- a/fair_forge/schemas/vision.py
+++ b/fair_forge/schemas/vision.py
@@ -1,0 +1,33 @@
+"""Pydantic schemas for vision metrics."""
+
+from pydantic import BaseModel
+
+from fair_forge.schemas.metrics import BaseMetric
+
+
+class VisionSimilarityInteraction(BaseModel):
+    qa_id: str
+    similarity_score: float
+
+
+class VisionSimilarityMetric(BaseMetric):
+    mean_similarity: float
+    min_similarity: float
+    max_similarity: float
+    summary: str
+    interactions: list[VisionSimilarityInteraction]
+
+
+class VisionHallucinationInteraction(BaseModel):
+    qa_id: str
+    similarity_score: float
+    is_hallucination: bool
+
+
+class VisionHallucinationMetric(BaseMetric):
+    hallucination_rate: float
+    n_hallucinations: int
+    n_frames: int
+    threshold: float
+    summary: str
+    interactions: list[VisionHallucinationInteraction]

--- a/fair_forge/schemas/vision.py
+++ b/fair_forge/schemas/vision.py
@@ -17,6 +17,15 @@ class VisionSimilarityMetric(BaseMetric):
     summary: str
     interactions: list[VisionSimilarityInteraction]
 
+    def display(self) -> None:
+        """Print a human-readable summary of the similarity results."""
+        print(f"Session: {self.session_id}  |  Assistant: {self.assistant_id}")
+        print(self.summary)
+        print()
+        for i in self.interactions:
+            print(f"  {i.qa_id}  similarity={i.similarity_score:.2f}")
+        print()
+
 
 class VisionHallucinationInteraction(BaseModel):
     qa_id: str
@@ -31,3 +40,13 @@ class VisionHallucinationMetric(BaseMetric):
     threshold: float
     summary: str
     interactions: list[VisionHallucinationInteraction]
+
+    def display(self) -> None:
+        """Print a human-readable summary of the hallucination results."""
+        print(f"Session: {self.session_id}  |  Assistant: {self.assistant_id}")
+        print(self.summary)
+        print()
+        for i in self.interactions:
+            label = "HALLUCINATION" if i.is_hallucination else "ok"
+            print(f"  {i.qa_id}  similarity={i.similarity_score:.2f}  {label}")
+        print()

--- a/fair_forge/scorers/__init__.py
+++ b/fair_forge/scorers/__init__.py
@@ -1,0 +1,5 @@
+"""Concrete SimilarityScorer implementations."""
+
+from .cosine import CosineSimilarity
+
+__all__ = ["CosineSimilarity"]

--- a/fair_forge/scorers/cosine.py
+++ b/fair_forge/scorers/cosine.py
@@ -1,0 +1,16 @@
+"""Cosine similarity scorer using a pluggable Embedder."""
+
+from fair_forge.core.embedder import Embedder
+from fair_forge.core.similarity_scorer import SimilarityScorer
+from fair_forge.utils.math import cosine_similarity
+
+
+class CosineSimilarity(SimilarityScorer):
+    """Computes semantic similarity using cosine distance between embeddings."""
+
+    def __init__(self, embedder: Embedder):
+        self._embedder = embedder
+
+    def calculate(self, assistant: str, ground_truth: str) -> float:
+        embeddings = self._embedder.encode([assistant, ground_truth])
+        return cosine_similarity(embeddings[0], embeddings[1])

--- a/fair_forge/utils/__init__.py
+++ b/fair_forge/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility functions and classes for Fair Forge."""
 
 from .logging import VerboseLogger
+from .math import cosine_similarity
 
-__all__ = ["VerboseLogger"]
+__all__ = ["VerboseLogger", "cosine_similarity"]

--- a/fair_forge/utils/math.py
+++ b/fair_forge/utils/math.py
@@ -1,0 +1,7 @@
+"""Common mathematical utilities for Fair Forge."""
+
+import numpy as np
+
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,12 @@ bias = [
     "torch>=2.0.0",
 ]
 
+vision = [
+    "numpy>=1.24.0",
+    "sentence-transformers>=5.0.0",
+    "torch>=2.0.0",
+]
+
 regulatory = [
     "torch>=2.0.0",
     "accelerate>=0.25.0",
@@ -105,7 +111,7 @@ explainability = [
 
 # All metrics
 metrics = [
-    "alquimia-fair-forge[context,conversational,bestof,agentic,humanity,toxicity,bias,regulatory]",
+    "alquimia-fair-forge[context,conversational,bestof,agentic,humanity,toxicity,bias,regulatory,vision]",
 ]
 
 # Runners module

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ from tests.fixtures.mock_data import (
     create_sample_batch,
     create_sample_dataset,
     create_toxicity_dataset,
+    create_vision_dataset,
 )
 from tests.fixtures.mock_retriever import (
     AgenticDatasetRetriever,
@@ -53,6 +54,7 @@ from tests.fixtures.mock_retriever import (
     RegulatoryDatasetRetriever,
     SingleDatasetRetriever,
     ToxicityDatasetRetriever,
+    VisionDatasetRetriever,
 )
 
 
@@ -180,6 +182,18 @@ def bestof_dataset_retriever() -> type[BestOfDatasetRetriever]:
 def agentic_dataset_retriever() -> type[AgenticDatasetRetriever]:
     """Fixture providing AgenticDatasetRetriever class."""
     return AgenticDatasetRetriever
+
+
+@pytest.fixture
+def vision_dataset() -> Dataset:
+    """Fixture providing a vision testing dataset."""
+    return create_vision_dataset()
+
+
+@pytest.fixture
+def vision_dataset_retriever() -> type[VisionDatasetRetriever]:
+    """Fixture providing VisionDatasetRetriever class."""
+    return VisionDatasetRetriever
 
 
 @pytest.fixture

--- a/tests/fixtures/mock_data.py
+++ b/tests/fixtures/mock_data.py
@@ -228,6 +228,43 @@ def create_multiple_datasets() -> list[Dataset]:
     ]
 
 
+def create_vision_dataset() -> Dataset:
+    """Create a dataset for vision metrics testing with VLM free-text descriptions."""
+    conversation = [
+        create_sample_batch(
+            qa_id="qa_001",
+            query="Describe what you observe in this camera frame.",
+            assistant="A person is lying on the floor near the entrance. They appear to have fallen.",
+            ground_truth_assistant="A person fell near the entrance and is lying on the floor.",
+        ),
+        create_sample_batch(
+            qa_id="qa_002",
+            query="Describe what you observe in this camera frame.",
+            assistant="The corridor appears empty. No persons or anomalies detected.",
+            ground_truth_assistant="The corridor is empty. No events have occurred.",
+        ),
+        create_sample_batch(
+            qa_id="qa_003",
+            query="Describe what you observe in this camera frame.",
+            assistant="An unauthorized person is attempting to access a restricted area.",
+            ground_truth_assistant="The restricted area is empty. No intrusion has occurred.",
+        ),
+        create_sample_batch(
+            qa_id="qa_004",
+            query="Describe what you observe in this camera frame.",
+            assistant="The parking lot appears normal. No incidents detected.",
+            ground_truth_assistant="A vehicle has been broken into in the parking lot.",
+        ),
+    ]
+    return create_sample_dataset(
+        session_id="vision_session",
+        assistant_id="argos_vlm",
+        context="Argos security camera surveillance system monitoring building entrances and restricted areas.",
+        conversation=conversation,
+    )
+
+
+
 def create_regulatory_dataset() -> Dataset:
     """Create a dataset for Regulatory metric testing."""
     conversation = [

--- a/tests/fixtures/mock_retriever.py
+++ b/tests/fixtures/mock_retriever.py
@@ -13,6 +13,7 @@ from tests.fixtures.mock_data import (
     create_regulatory_dataset,
     create_sample_dataset,
     create_toxicity_dataset,
+    create_vision_dataset,
 )
 
 
@@ -115,6 +116,14 @@ class AgenticDatasetRetriever(Retriever):
     def load_dataset(self) -> list[Dataset]:
         """Return agentic testing dataset with K responses."""
         return create_agentic_dataset()
+
+
+class VisionDatasetRetriever(Retriever):
+    """Mock retriever for Vision metric testing."""
+
+    def load_dataset(self) -> list[Dataset]:
+        """Return vision testing dataset."""
+        return [create_vision_dataset()]
 
 
 class RegulatoryDatasetRetriever(Retriever):

--- a/tests/metrics/test_vision.py
+++ b/tests/metrics/test_vision.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 
 from fair_forge.metrics.vision import VisionHallucination, VisionSimilarity
@@ -10,14 +9,11 @@ from fair_forge.schemas.vision import VisionHallucinationMetric, VisionSimilarit
 from tests.fixtures.mock_data import create_sample_batch, create_sample_dataset
 from tests.fixtures.mock_retriever import MockRetriever, VisionDatasetRetriever
 
-_HIGH = np.array([1.0, 0.0])  # cosine similarity = 1.0
-_LOW = np.array([0.0, 1.0])   # cosine similarity = 0.0
 
-
-def _mock_encoder(encode_sequence: list[np.ndarray]):
-    encoder = MagicMock()
-    encoder.encode.side_effect = encode_sequence
-    return encoder
+def _mock_scorer(similarities: list[float]):
+    scorer = MagicMock()
+    scorer.calculate.side_effect = similarities
+    return scorer
 
 
 def _vision_retriever(batches):
@@ -38,10 +34,9 @@ def _batch(qa_id: str):
     )
 
 
-def _run_metric(metric_class, batches, encoder, threshold=0.75):
+def _run_metric(metric_class, batches, scorer, threshold=0.75):
     retriever = _vision_retriever(batches)
-    metric = metric_class(retriever, threshold=threshold)
-    metric._encoder = encoder
+    metric = metric_class(retriever, scorer=scorer, threshold=threshold)
     metric.batch(session_id="vision_session", context="camera", assistant_id="vlm", batch=batches)
     metric.on_process_complete()
     return metric
@@ -49,14 +44,14 @@ def _run_metric(metric_class, batches, encoder, threshold=0.75):
 
 class TestVisionSimilarity:
     def test_initialization(self, vision_dataset_retriever):
-        metric = VisionSimilarity(vision_dataset_retriever)
+        scorer = _mock_scorer([])
+        metric = VisionSimilarity(vision_dataset_retriever, scorer=scorer)
         assert metric._session_data == {}
         assert metric._threshold == 0.75
 
     def test_perfect_similarity(self):
         batches = [_batch("qa_001"), _batch("qa_002")]
-        encoder = _mock_encoder([np.array([_HIGH, _HIGH]), np.array([_HIGH, _HIGH])])
-        metric = _run_metric(VisionSimilarity, batches, encoder)
+        metric = _run_metric(VisionSimilarity, batches, _mock_scorer([1.0, 1.0]))
 
         result = metric.metrics[0]
         assert isinstance(result, VisionSimilarityMetric)
@@ -66,8 +61,7 @@ class TestVisionSimilarity:
 
     def test_mixed_similarity(self):
         batches = [_batch("qa_001"), _batch("qa_002")]
-        encoder = _mock_encoder([np.array([_HIGH, _LOW]), np.array([_HIGH, _HIGH])])
-        metric = _run_metric(VisionSimilarity, batches, encoder)
+        metric = _run_metric(VisionSimilarity, batches, _mock_scorer([1.0, 0.0]))
 
         result = metric.metrics[0]
         assert result.mean_similarity == pytest.approx(0.5, abs=0.01)
@@ -76,8 +70,7 @@ class TestVisionSimilarity:
 
     def test_summary_contains_key_info(self):
         batches = [_batch("qa_001")]
-        encoder = _mock_encoder([np.array([_HIGH]), np.array([_HIGH])])
-        metric = _run_metric(VisionSimilarity, batches, encoder)
+        metric = _run_metric(VisionSimilarity, batches, _mock_scorer([1.0]))
 
         summary = metric.metrics[0].summary
         assert "100%" in summary
@@ -85,8 +78,7 @@ class TestVisionSimilarity:
 
     def test_interactions_stored(self):
         batches = [_batch("qa_001"), _batch("qa_002")]
-        encoder = _mock_encoder([np.array([_HIGH, _LOW]), np.array([_HIGH, _HIGH])])
-        metric = _run_metric(VisionSimilarity, batches, encoder)
+        metric = _run_metric(VisionSimilarity, batches, _mock_scorer([1.0, 0.0]))
 
         interactions = metric.metrics[0].interactions
         assert len(interactions) == 2
@@ -99,12 +91,8 @@ class TestVisionSimilarity:
         dataset_b = create_sample_dataset(session_id="session_b", conversation=batches)
         retriever = type("R", (MockRetriever,), {"load_dataset": lambda self: [dataset_a, dataset_b]})
 
-        encoder = _mock_encoder([
-            np.array([_HIGH]), np.array([_HIGH]),
-            np.array([_HIGH]), np.array([_HIGH]),
-        ])
-        metric = VisionSimilarity(retriever)
-        metric._encoder = encoder
+        scorer = _mock_scorer([1.0, 1.0])
+        metric = VisionSimilarity(retriever, scorer=scorer)
         metric.batch(session_id="session_a", context="cam", assistant_id="vlm", batch=batches)
         metric.batch(session_id="session_b", context="cam", assistant_id="vlm", batch=batches)
         metric.on_process_complete()
@@ -112,13 +100,8 @@ class TestVisionSimilarity:
         assert len(metric.metrics) == 2
 
     def test_run_method(self, vision_dataset_retriever):
-        mock_encoder = MagicMock()
-        mock_encoder.encode.side_effect = [
-            np.array([_HIGH, _HIGH, _LOW, _LOW]),
-            np.array([_HIGH, _HIGH, _HIGH, _HIGH]),
-        ]
-        with patch.object(VisionSimilarity, "_get_encoder", return_value=mock_encoder):
-            results = VisionSimilarity.run(vision_dataset_retriever, verbose=False)
+        scorer = _mock_scorer([1.0, 1.0, 1.0, 1.0])
+        results = VisionSimilarity.run(vision_dataset_retriever, scorer=scorer, verbose=False)
 
         assert isinstance(results, list)
         assert isinstance(results[0], VisionSimilarityMetric)
@@ -126,14 +109,14 @@ class TestVisionSimilarity:
 
 class TestVisionHallucination:
     def test_initialization(self, vision_dataset_retriever):
-        metric = VisionHallucination(vision_dataset_retriever)
+        scorer = _mock_scorer([])
+        metric = VisionHallucination(vision_dataset_retriever, scorer=scorer)
         assert metric._session_data == {}
         assert metric._threshold == 0.75
 
     def test_no_hallucinations(self):
         batches = [_batch("qa_001"), _batch("qa_002")]
-        encoder = _mock_encoder([np.array([_HIGH, _HIGH]), np.array([_HIGH, _HIGH])])
-        metric = _run_metric(VisionHallucination, batches, encoder)
+        metric = _run_metric(VisionHallucination, batches, _mock_scorer([1.0, 1.0]))
 
         result = metric.metrics[0]
         assert isinstance(result, VisionHallucinationMetric)
@@ -142,8 +125,7 @@ class TestVisionHallucination:
 
     def test_all_hallucinations(self):
         batches = [_batch("qa_001"), _batch("qa_002")]
-        encoder = _mock_encoder([np.array([_HIGH, _HIGH]), np.array([_LOW, _LOW])])
-        metric = _run_metric(VisionHallucination, batches, encoder)
+        metric = _run_metric(VisionHallucination, batches, _mock_scorer([0.0, 0.0]))
 
         result = metric.metrics[0]
         assert result.n_hallucinations == 2
@@ -151,8 +133,7 @@ class TestVisionHallucination:
 
     def test_partial_hallucinations(self):
         batches = [_batch("qa_001"), _batch("qa_002"), _batch("qa_003")]
-        encoder = _mock_encoder([np.array([_HIGH, _HIGH, _LOW]), np.array([_HIGH, _HIGH, _HIGH])])
-        metric = _run_metric(VisionHallucination, batches, encoder)
+        metric = _run_metric(VisionHallucination, batches, _mock_scorer([1.0, 1.0, 0.0]))
 
         result = metric.metrics[0]
         assert result.n_hallucinations == 1
@@ -161,23 +142,20 @@ class TestVisionHallucination:
 
     def test_configurable_threshold(self):
         batches = [_batch("qa_001")]
-        encoder = _mock_encoder([np.array([_HIGH]), np.array([_LOW])])
         # similarity = 0.0, threshold = 0.0 → 0.0 < 0.0 is False → not a hallucination
-        metric = _run_metric(VisionHallucination, batches, encoder, threshold=0.0)
+        metric = _run_metric(VisionHallucination, batches, _mock_scorer([0.0]), threshold=0.0)
 
         assert metric.metrics[0].n_hallucinations == 0
 
     def test_threshold_stored_in_result(self):
         batches = [_batch("qa_001")]
-        encoder = _mock_encoder([np.array([_HIGH]), np.array([_HIGH])])
-        metric = _run_metric(VisionHallucination, batches, encoder, threshold=0.8)
+        metric = _run_metric(VisionHallucination, batches, _mock_scorer([1.0]), threshold=0.8)
 
         assert metric.metrics[0].threshold == 0.8
 
     def test_summary_contains_key_info(self):
         batches = [_batch("qa_001"), _batch("qa_002")]
-        encoder = _mock_encoder([np.array([_HIGH, _LOW]), np.array([_HIGH, _HIGH])])
-        metric = _run_metric(VisionHallucination, batches, encoder)
+        metric = _run_metric(VisionHallucination, batches, _mock_scorer([1.0, 0.0]))
 
         summary = metric.metrics[0].summary
         assert "1 of 2" in summary
@@ -185,21 +163,15 @@ class TestVisionHallucination:
 
     def test_interactions_classified_correctly(self):
         batches = [_batch("qa_001"), _batch("qa_002")]
-        encoder = _mock_encoder([np.array([_HIGH, _LOW]), np.array([_HIGH, _HIGH])])
-        metric = _run_metric(VisionHallucination, batches, encoder)
+        metric = _run_metric(VisionHallucination, batches, _mock_scorer([1.0, 0.0]))
 
         interactions = metric.metrics[0].interactions
         assert interactions[0].is_hallucination is False
         assert interactions[1].is_hallucination is True
 
     def test_run_method(self, vision_dataset_retriever):
-        mock_encoder = MagicMock()
-        mock_encoder.encode.side_effect = [
-            np.array([_HIGH, _HIGH, _LOW, _LOW]),
-            np.array([_HIGH, _HIGH, _HIGH, _HIGH]),
-        ]
-        with patch.object(VisionHallucination, "_get_encoder", return_value=mock_encoder):
-            results = VisionHallucination.run(vision_dataset_retriever, verbose=False)
+        scorer = _mock_scorer([1.0, 1.0, 1.0, 1.0])
+        results = VisionHallucination.run(vision_dataset_retriever, scorer=scorer, verbose=False)
 
         assert isinstance(results, list)
         assert isinstance(results[0], VisionHallucinationMetric)

--- a/tests/metrics/test_vision.py
+++ b/tests/metrics/test_vision.py
@@ -1,0 +1,205 @@
+"""Unit tests for vision metrics: VisionSimilarity, VisionHallucination."""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from fair_forge.metrics.vision import VisionHallucination, VisionSimilarity
+from fair_forge.schemas.vision import VisionHallucinationMetric, VisionSimilarityMetric
+from tests.fixtures.mock_data import create_sample_batch, create_sample_dataset
+from tests.fixtures.mock_retriever import MockRetriever, VisionDatasetRetriever
+
+_HIGH = np.array([1.0, 0.0])  # cosine similarity = 1.0
+_LOW = np.array([0.0, 1.0])   # cosine similarity = 0.0
+
+
+def _mock_encoder(encode_sequence: list[np.ndarray]):
+    encoder = MagicMock()
+    encoder.encode.side_effect = encode_sequence
+    return encoder
+
+
+def _vision_retriever(batches):
+    dataset = create_sample_dataset(
+        session_id="vision_session",
+        assistant_id="argos_vlm",
+        context="Argos security camera",
+        conversation=batches,
+    )
+    return type("VisionRetriever", (MockRetriever,), {"load_dataset": lambda self: [dataset]})
+
+
+def _batch(qa_id: str):
+    return create_sample_batch(
+        qa_id=qa_id,
+        assistant="VLM description",
+        ground_truth_assistant="Ground truth description",
+    )
+
+
+def _run_metric(metric_class, batches, encoder, threshold=0.75):
+    retriever = _vision_retriever(batches)
+    metric = metric_class(retriever, threshold=threshold)
+    metric._encoder = encoder
+    metric.batch(session_id="vision_session", context="camera", assistant_id="vlm", batch=batches)
+    metric.on_process_complete()
+    return metric
+
+
+class TestVisionSimilarity:
+    def test_initialization(self, vision_dataset_retriever):
+        metric = VisionSimilarity(vision_dataset_retriever)
+        assert metric._session_data == {}
+        assert metric._threshold == 0.75
+
+    def test_perfect_similarity(self):
+        batches = [_batch("qa_001"), _batch("qa_002")]
+        encoder = _mock_encoder([np.array([_HIGH, _HIGH]), np.array([_HIGH, _HIGH])])
+        metric = _run_metric(VisionSimilarity, batches, encoder)
+
+        result = metric.metrics[0]
+        assert isinstance(result, VisionSimilarityMetric)
+        assert result.mean_similarity == pytest.approx(1.0)
+        assert result.min_similarity == pytest.approx(1.0)
+        assert result.max_similarity == pytest.approx(1.0)
+
+    def test_mixed_similarity(self):
+        batches = [_batch("qa_001"), _batch("qa_002")]
+        encoder = _mock_encoder([np.array([_HIGH, _LOW]), np.array([_HIGH, _HIGH])])
+        metric = _run_metric(VisionSimilarity, batches, encoder)
+
+        result = metric.metrics[0]
+        assert result.mean_similarity == pytest.approx(0.5, abs=0.01)
+        assert result.min_similarity == pytest.approx(0.0, abs=0.01)
+        assert result.max_similarity == pytest.approx(1.0, abs=0.01)
+
+    def test_summary_contains_key_info(self):
+        batches = [_batch("qa_001")]
+        encoder = _mock_encoder([np.array([_HIGH]), np.array([_HIGH])])
+        metric = _run_metric(VisionSimilarity, batches, encoder)
+
+        summary = metric.metrics[0].summary
+        assert "100%" in summary
+        assert "1 frames" in summary
+
+    def test_interactions_stored(self):
+        batches = [_batch("qa_001"), _batch("qa_002")]
+        encoder = _mock_encoder([np.array([_HIGH, _LOW]), np.array([_HIGH, _HIGH])])
+        metric = _run_metric(VisionSimilarity, batches, encoder)
+
+        interactions = metric.metrics[0].interactions
+        assert len(interactions) == 2
+        assert interactions[0].qa_id == "qa_001"
+        assert interactions[0].similarity_score is not None
+
+    def test_multiple_sessions(self):
+        batches = [_batch("qa_001")]
+        dataset_a = create_sample_dataset(session_id="session_a", conversation=batches)
+        dataset_b = create_sample_dataset(session_id="session_b", conversation=batches)
+        retriever = type("R", (MockRetriever,), {"load_dataset": lambda self: [dataset_a, dataset_b]})
+
+        encoder = _mock_encoder([
+            np.array([_HIGH]), np.array([_HIGH]),
+            np.array([_HIGH]), np.array([_HIGH]),
+        ])
+        metric = VisionSimilarity(retriever)
+        metric._encoder = encoder
+        metric.batch(session_id="session_a", context="cam", assistant_id="vlm", batch=batches)
+        metric.batch(session_id="session_b", context="cam", assistant_id="vlm", batch=batches)
+        metric.on_process_complete()
+
+        assert len(metric.metrics) == 2
+
+    def test_run_method(self, vision_dataset_retriever):
+        mock_encoder = MagicMock()
+        mock_encoder.encode.side_effect = [
+            np.array([_HIGH, _HIGH, _LOW, _LOW]),
+            np.array([_HIGH, _HIGH, _HIGH, _HIGH]),
+        ]
+        with patch.object(VisionSimilarity, "_get_encoder", return_value=mock_encoder):
+            results = VisionSimilarity.run(vision_dataset_retriever, verbose=False)
+
+        assert isinstance(results, list)
+        assert isinstance(results[0], VisionSimilarityMetric)
+
+
+class TestVisionHallucination:
+    def test_initialization(self, vision_dataset_retriever):
+        metric = VisionHallucination(vision_dataset_retriever)
+        assert metric._session_data == {}
+        assert metric._threshold == 0.75
+
+    def test_no_hallucinations(self):
+        batches = [_batch("qa_001"), _batch("qa_002")]
+        encoder = _mock_encoder([np.array([_HIGH, _HIGH]), np.array([_HIGH, _HIGH])])
+        metric = _run_metric(VisionHallucination, batches, encoder)
+
+        result = metric.metrics[0]
+        assert isinstance(result, VisionHallucinationMetric)
+        assert result.n_hallucinations == 0
+        assert result.hallucination_rate == pytest.approx(0.0)
+
+    def test_all_hallucinations(self):
+        batches = [_batch("qa_001"), _batch("qa_002")]
+        encoder = _mock_encoder([np.array([_HIGH, _HIGH]), np.array([_LOW, _LOW])])
+        metric = _run_metric(VisionHallucination, batches, encoder)
+
+        result = metric.metrics[0]
+        assert result.n_hallucinations == 2
+        assert result.hallucination_rate == pytest.approx(1.0)
+
+    def test_partial_hallucinations(self):
+        batches = [_batch("qa_001"), _batch("qa_002"), _batch("qa_003")]
+        encoder = _mock_encoder([np.array([_HIGH, _HIGH, _LOW]), np.array([_HIGH, _HIGH, _HIGH])])
+        metric = _run_metric(VisionHallucination, batches, encoder)
+
+        result = metric.metrics[0]
+        assert result.n_hallucinations == 1
+        assert result.n_frames == 3
+        assert result.hallucination_rate == pytest.approx(1 / 3, abs=0.01)
+
+    def test_configurable_threshold(self):
+        batches = [_batch("qa_001")]
+        encoder = _mock_encoder([np.array([_HIGH]), np.array([_LOW])])
+        # similarity = 0.0, threshold = 0.0 → 0.0 < 0.0 is False → not a hallucination
+        metric = _run_metric(VisionHallucination, batches, encoder, threshold=0.0)
+
+        assert metric.metrics[0].n_hallucinations == 0
+
+    def test_threshold_stored_in_result(self):
+        batches = [_batch("qa_001")]
+        encoder = _mock_encoder([np.array([_HIGH]), np.array([_HIGH])])
+        metric = _run_metric(VisionHallucination, batches, encoder, threshold=0.8)
+
+        assert metric.metrics[0].threshold == 0.8
+
+    def test_summary_contains_key_info(self):
+        batches = [_batch("qa_001"), _batch("qa_002")]
+        encoder = _mock_encoder([np.array([_HIGH, _LOW]), np.array([_HIGH, _HIGH])])
+        metric = _run_metric(VisionHallucination, batches, encoder)
+
+        summary = metric.metrics[0].summary
+        assert "1 of 2" in summary
+        assert "0.75" in summary
+
+    def test_interactions_classified_correctly(self):
+        batches = [_batch("qa_001"), _batch("qa_002")]
+        encoder = _mock_encoder([np.array([_HIGH, _LOW]), np.array([_HIGH, _HIGH])])
+        metric = _run_metric(VisionHallucination, batches, encoder)
+
+        interactions = metric.metrics[0].interactions
+        assert interactions[0].is_hallucination is False
+        assert interactions[1].is_hallucination is True
+
+    def test_run_method(self, vision_dataset_retriever):
+        mock_encoder = MagicMock()
+        mock_encoder.encode.side_effect = [
+            np.array([_HIGH, _HIGH, _LOW, _LOW]),
+            np.array([_HIGH, _HIGH, _HIGH, _HIGH]),
+        ]
+        with patch.object(VisionHallucination, "_get_encoder", return_value=mock_encoder):
+            results = VisionHallucination.run(vision_dataset_retriever, verbose=False)
+
+        assert isinstance(results, list)
+        assert isinstance(results[0], VisionHallucinationMetric)

--- a/uv.lock
+++ b/uv.lock
@@ -199,7 +199,7 @@ wheels = [
 
 [[package]]
 name = "alquimia-fair-forge"
-version = "2.0.0b3"
+version = "3.0.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -304,6 +304,11 @@ toxicity = [
     { name = "torch" },
     { name = "umap-learn" },
 ]
+vision = [
+    { name = "numpy" },
+    { name = "sentence-transformers" },
+    { name = "torch" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -333,7 +338,7 @@ requires-dist = [
     { name = "aiosseclient", marker = "extra == 'runners'", specifier = ">=0.1.8" },
     { name = "alquimia-client", marker = "extra == 'generators-alquimia'", specifier = ">=0.1.0" },
     { name = "alquimia-client", marker = "extra == 'runners'", specifier = ">=0.1.0" },
-    { name = "alquimia-fair-forge", extras = ["context", "conversational", "bestof", "agentic", "humanity", "toxicity", "bias", "regulatory"], marker = "extra == 'metrics'" },
+    { name = "alquimia-fair-forge", extras = ["context", "conversational", "bestof", "agentic", "humanity", "toxicity", "bias", "regulatory", "vision"], marker = "extra == 'metrics'" },
     { name = "alquimia-fair-forge", extras = ["metrics", "runners", "generators", "generators-alquimia", "explainability", "prompt-optimizer"], marker = "extra == 'all'" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "hdbscan", marker = "extra == 'toxicity'", specifier = ">=0.8.41" },
@@ -352,6 +357,7 @@ requires-dist = [
     { name = "numba", marker = "extra == 'toxicity'", specifier = ">=0.57.0" },
     { name = "numpy", marker = "extra == 'humanity'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'toxicity'", specifier = ">=1.24.0" },
+    { name = "numpy", marker = "extra == 'vision'", specifier = ">=1.24.0" },
     { name = "optuna", specifier = ">=4.7.0" },
     { name = "optuna", marker = "extra == 'prompt-optimizer'", specifier = ">=3.0.0" },
     { name = "pandas", marker = "extra == 'humanity'", specifier = ">=2.0.0" },
@@ -369,12 +375,14 @@ requires-dist = [
     { name = "scikit-learn", marker = "extra == 'toxicity'", specifier = ">=1.3.0,<1.8" },
     { name = "scipy", specifier = ">=1.14.1" },
     { name = "sentence-transformers", marker = "extra == 'toxicity'", specifier = ">=5.0.0" },
+    { name = "sentence-transformers", marker = "extra == 'vision'", specifier = ">=5.0.0" },
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "sphinx-rtd-theme", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "torch", marker = "extra == 'bias'", specifier = ">=2.0.0" },
     { name = "torch", marker = "extra == 'explainability'", specifier = ">=2.0.0" },
     { name = "torch", marker = "extra == 'regulatory'", specifier = ">=2.0.0" },
     { name = "torch", marker = "extra == 'toxicity'", specifier = ">=2.0.0" },
+    { name = "torch", marker = "extra == 'vision'", specifier = ">=2.0.0" },
     { name = "tqdm", specifier = ">=4.65.0" },
     { name = "transformers", specifier = ">=4.35.0" },
     { name = "transformers", marker = "extra == 'explainability'", specifier = ">=4.35.0" },
@@ -382,7 +390,7 @@ requires-dist = [
     { name = "umap-learn", marker = "extra == 'toxicity'", specifier = ">=0.5.6,<0.6.0" },
     { name = "virtualenv", marker = "extra == 'dev'", specifier = ">=20.36.1" },
 ]
-provides-extras = ["context", "conversational", "bestof", "agentic", "humanity", "toxicity", "bias", "regulatory", "explainability", "metrics", "runners", "prompt-optimizer", "generators", "generators-alquimia", "all", "dev"]
+provides-extras = ["context", "conversational", "bestof", "agentic", "humanity", "toxicity", "bias", "vision", "regulatory", "explainability", "metrics", "runners", "prompt-optimizer", "generators", "generators-alquimia", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1394,6 +1402,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -1402,6 +1411,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1410,6 +1420,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1418,6 +1429,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -1426,6 +1438,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },


### PR DESCRIPTION
## Summary

This PR introduces two new metrics for evaluating Vision Language Models (VLMs): **VisionSimilarity** and **VisionHallucination**. Both metrics compare the VLM's free-text scene descriptions against human-annotated ground truth using cosine similarity between sentence embeddings (`all-mpnet-base-v2`).

### VisionSimilarity

Measures how semantically accurate the VLM descriptions are across a session. For each frame it computes the cosine similarity between the VLM output and the ground truth, then aggregates into `mean`, `min`, and `max` scores. A score of `1.0` means semantically identical; `0.0` means completely unrelated.

### VisionHallucination

Measures how often the VLM describes a scene that significantly differs from what actually happened. A frame is flagged as a hallucination when the cosine similarity falls below a configurable `threshold` (default `0.75`). The metric reports `hallucination_rate`, `n_hallucinations`, and per-frame detail.

### Dataset format

Each session is a standard Fair Forge `Dataset`. Each `Batch` only requires two fields:
- `assistant` — free-text description produced by the VLM
- `ground_truth_assistant` — human-annotated description of the scene

### DX improvements

- `display()` method added to both result schemas (`VisionSimilarityMetric`, `VisionHallucinationMetric`) so users can inspect results in a single call instead of writing custom loops
- `THRESHOLD` exposed as a top-level variable in the example notebook with inline guidance on how to tune it per domain
- `vision` optional dependency group added to `pyproject.toml` (`sentence-transformers`, `torch`, `numpy`)
- Example dataset (`dataset.json`) included for the security camera surveillance use case

## Test plan

- [ ] Run `VisionSimilarity.run(VLMRetriever)` on the example dataset and verify per-session summary and interactions
- [ ] Run `VisionHallucination.run(VLMRetriever, threshold=0.75)` and verify hallucination flags per frame
- [ ] Call `.display()` on both result types and confirm output format
- [ ] Install with `pip install alquimia-fair-forge[vision]` and confirm dependencies resolve correctly
- [ ] Adjust `THRESHOLD` in the notebook and confirm the hallucination count changes accordingly