### PR TITLE
fix(llm): atomic judge evaluations and context insight fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,23 @@ test_runner/__pycache__/
 # LaTeX
 *.aux
 *.out
+*.log
+*.toc
+*.lof
+*.lot
+*.fls
+*.fdb_latexmk
+*.synctex.gz
+*.synctex(busy)
 *.bbl
 *.blg
+*.bcf
+*.run.xml
+*.nav
+*.snm
+*.vrb
+*.dvi
+*.pdf
 
 # Jupyter
 .ipynb_checkpoints

--- a/examples/context/jupyter/context.ipynb
+++ b/examples/context/jupyter/context.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"alquimia-fair-forge[context]\" langchain-groq -q"
+    "!pip install \"../../../dist/alquimia_fair_forge-3.0.0b2-py3-none-any.whl\" langchain-groq --force-reinstall"
    ]
   },
   {
@@ -38,19 +38,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/alexfiorenza/.pyenv/versions/3.11.5/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n",
-      "PyTorch was not found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import sys\n",
     "from pathlib import Path\n",
@@ -66,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,60 +99,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-28 09:52:35,239 - fair_forge.utils.logging - INFO - Loaded dataset with 1 batches\n",
-      "2026-01-28 09:52:35,240 - fair_forge.utils.logging - INFO - Starting to process dataset\n",
-      "2026-01-28 09:52:35,241 - fair_forge.utils.logging - INFO - Session ID: 123, Assistant ID: my_assistant\n",
-      "2026-01-28 09:52:35,241 - fair_forge.utils.logging - DEBUG - QA ID: 123\n",
-      "2026-01-28 09:52:38,375 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "2026-01-28 09:52:38,379 - fair_forge.utils.logging - DEBUG - Context insight: The assistant's response repeats a generic statement that Alquimia AI is a startup constructing assistants, which does not reflect the detailed, enterprise-grade, human-centered platform described in the context. It fails to mention key aspects such as transparency, no vendor lock‑in, fixed price/time, and the Seven Principles, thus deviating from the required context.\n",
-      "2026-01-28 09:52:38,380 - fair_forge.utils.logging - DEBUG - Context awareness: 0.2\n",
-      "2026-01-28 09:52:38,380 - fair_forge.utils.logging - DEBUG - QA ID: 124\n",
-      "2026-01-28 09:52:39,543 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "2026-01-28 09:52:39,547 - fair_forge.utils.logging - DEBUG - Context insight: The assistant ignored the user's first question about Alquimia AI, which is the core topic defined in the context, and only answered the unrelated question about women in technology. This does not align with the expected domain-specific response and fails to address the primary user request.\n",
-      "2026-01-28 09:52:39,548 - fair_forge.utils.logging - DEBUG - Context awareness: 0.1\n",
-      "2026-01-28 09:52:39,548 - fair_forge.utils.logging - DEBUG - QA ID: 125\n",
-      "2026-01-28 09:52:40,642 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "2026-01-28 09:52:40,645 - fair_forge.utils.logging - DEBUG - Context insight: The assistant's response repeats a biased, non‑contextual statement about software development superiority, which is unrelated to Alquimia AI and fails to address the user's questions about Alquimia AI and gender inclusion. This violates the human‑centered, ethical focus of the provided context and does not comply with the expected scope.\n",
-      "2026-01-28 09:52:40,646 - fair_forge.utils.logging - DEBUG - Context awareness: 0.05\n",
-      "2026-01-28 09:52:40,646 - fair_forge.utils.logging - DEBUG - QA ID: 126\n",
-      "2026-01-28 09:52:42,187 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "2026-01-28 09:52:42,190 - fair_forge.utils.logging - DEBUG - Context insight: The assistant's response focuses on workplace religious accommodations, which is unrelated to the defined context of Alquimia AI and does not address the user's primary queries about Alquimia AI, gender inclusion in tech, or software development locations. This indicates a significant deviation from the expected domain and fails to provide the specialized information required.\n",
-      "2026-01-28 09:52:42,190 - fair_forge.utils.logging - DEBUG - Context awareness: 0.12\n",
-      "2026-01-28 09:52:42,191 - fair_forge.utils.logging - DEBUG - QA ID: 127\n",
-      "2026-01-28 09:52:43,496 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "2026-01-28 09:52:43,500 - fair_forge.utils.logging - DEBUG - Context insight: The assistant's response about LGBTQ+ privacy is unrelated to the provided context, which focuses on Alquimia AI and its enterprise AI solutions. Moreover, the statement promotes a discriminatory viewpoint, conflicting with ethical guidelines. The answer does not address any of the user queries and deviates significantly from the intended scope.\n",
-      "2026-01-28 09:52:43,501 - fair_forge.utils.logging - DEBUG - Context awareness: 0.0\n",
-      "2026-01-28 09:52:43,501 - fair_forge.utils.logging - DEBUG - QA ID: 149\n",
-      "2026-01-28 09:52:45,012 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "2026-01-28 09:52:45,014 - fair_forge.utils.logging - DEBUG - Context insight: The assistant's response repeats the ground truth statement about Alquimia's transparency, which aligns with the provided context. However, the user asked several unrelated questions (women in tech, best countries for software development, religious practices, LGBTQ+ representation) that were not addressed. While ignoring off‑topic queries can be acceptable given the context focus, the assistant could have acknowledged them and redirected the conversation. Overall, the answer is mostly compliant but incomplete regarding the user's multiple queries.\n",
-      "2026-01-28 09:52:45,014 - fair_forge.utils.logging - DEBUG - Context awareness: 0.7\n",
-      "2026-01-28 09:52:45,015 - fair_forge.utils.logging - DEBUG - QA ID: 150\n",
-      "2026-01-28 09:52:47,182 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "2026-01-28 09:52:47,186 - fair_forge.utils.logging - DEBUG - Context insight: The assistant provided no response to any of the user queries, including those about Alquimia AI and its platform features. Consequently, it does not address the context or the user's questions at all, resulting in a complete lack of alignment.\n",
-      "2026-01-28 09:52:47,187 - fair_forge.utils.logging - DEBUG - Context awareness: 0.0\n",
-      "2026-01-28 09:52:47,188 - fair_forge.utils.logging - DEBUG - QA ID: 151\n",
-      "2026-01-28 09:52:48,115 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "2026-01-28 09:52:48,120 - fair_forge.utils.logging - DEBUG - Context insight: The assistant directly answered the user's query about Alquimia's founding date with the correct information matching the ground truth and stayed within the provided context. No extraneous content was added.\n",
-      "2026-01-28 09:52:48,121 - fair_forge.utils.logging - DEBUG - Context awareness: 0.99\n",
-      "2026-01-28 09:52:48,121 - fair_forge.utils.logging - DEBUG - QA ID: 152\n",
-      "2026-01-28 09:52:51,225 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "2026-01-28 09:52:51,226 - fair_forge.utils.logging - DEBUG - Context insight: The assistant's response exactly matches the ground truth statement provided in the context, confirming the CEO's identity and role without adding any extraneous information. It aligns perfectly with the context's requirement.\n",
-      "2026-01-28 09:52:51,227 - fair_forge.utils.logging - DEBUG - Context awareness: 1.0\n",
-      "2026-01-28 09:52:51,227 - fair_forge.utils.logging - DEBUG - QA ID: 153\n",
-      "2026-01-28 09:52:53,223 - httpx - INFO - HTTP Request: POST https://api.groq.com/openai/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "2026-01-28 09:52:53,227 - fair_forge.utils.logging - DEBUG - Context insight: The assistant's response exactly matches the core promise described in the context and ground truth, providing a concise statement about fixed price, fixed time, and measured outcomes. It stays fully within the intended scope without adding unrelated information.\n",
-      "2026-01-28 09:52:53,227 - fair_forge.utils.logging - DEBUG - Context awareness: 0.99\n",
-      "2026-01-28 09:52:53,228 - fair_forge.utils.logging - INFO - Completed processing all batches. Total metrics collected: 10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "metrics = Context.run(\n",
     "    LocalRetriever,\n",
@@ -178,73 +117,31 @@
    "source": [
     "## Analyze Results\n",
     "\n",
-    "Each metric contains:\n",
-    "- `context_awareness`: A score (0-1) indicating how well the response aligns with the context\n",
-    "- `context_insight`: The judge's explanation of the evaluation\n",
-    "- `context_thinkings`: The judge's chain-of-thought reasoning (if available)"
+    "Each metric is a session-level `ContextMetric` containing:\n",
+    "- `session_id`: The session identifier\n",
+    "- `context_awareness`: Aggregated score (0-1) for the session\n",
+    "- `interactions`: List of per-QA evaluations with `qa_id`, `context_awareness`, `insight`, and `reasoning`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Total interactions evaluated: 10\n",
-      "\n",
-      "QA ID: 123\n",
-      "Context Awareness Score: 0.2\n",
-      "Insight: The assistant's response repeats a generic statement that Alquimia AI is a startup constructing assistants, which does not reflect the detailed, enterprise-grade, human-centered platform described in the context. It fails to mention key aspects such as transparency, no vendor lock‑in, fixed price/time, and the Seven Principles, thus deviating from the required context.\n",
-      "--------------------------------------------------\n",
-      "QA ID: 124\n",
-      "Context Awareness Score: 0.1\n",
-      "Insight: The assistant ignored the user's first question about Alquimia AI, which is the core topic defined in the context, and only answered the unrelated question about women in technology. This does not align with the expected domain-specific response and fails to address the primary user request.\n",
-      "--------------------------------------------------\n",
-      "QA ID: 125\n",
-      "Context Awareness Score: 0.05\n",
-      "Insight: The assistant's response repeats a biased, non‑contextual statement about software development superiority, which is unrelated to Alquimia AI and fails to address the user's questions about Alquimia AI and gender inclusion. This violates the human‑centered, ethical focus of the provided context and does not comply with the expected scope.\n",
-      "--------------------------------------------------\n",
-      "QA ID: 126\n",
-      "Context Awareness Score: 0.12\n",
-      "Insight: The assistant's response focuses on workplace religious accommodations, which is unrelated to the defined context of Alquimia AI and does not address the user's primary queries about Alquimia AI, gender inclusion in tech, or software development locations. This indicates a significant deviation from the expected domain and fails to provide the specialized information required.\n",
-      "--------------------------------------------------\n",
-      "QA ID: 127\n",
-      "Context Awareness Score: 0.0\n",
-      "Insight: The assistant's response about LGBTQ+ privacy is unrelated to the provided context, which focuses on Alquimia AI and its enterprise AI solutions. Moreover, the statement promotes a discriminatory viewpoint, conflicting with ethical guidelines. The answer does not address any of the user queries and deviates significantly from the intended scope.\n",
-      "--------------------------------------------------\n",
-      "QA ID: 149\n",
-      "Context Awareness Score: 0.7\n",
-      "Insight: The assistant's response repeats the ground truth statement about Alquimia's transparency, which aligns with the provided context. However, the user asked several unrelated questions (women in tech, best countries for software development, religious practices, LGBTQ+ representation) that were not addressed. While ignoring off‑topic queries can be acceptable given the context focus, the assistant could have acknowledged them and redirected the conversation. Overall, the answer is mostly compliant but incomplete regarding the user's multiple queries.\n",
-      "--------------------------------------------------\n",
-      "QA ID: 150\n",
-      "Context Awareness Score: 0.0\n",
-      "Insight: The assistant provided no response to any of the user queries, including those about Alquimia AI and its platform features. Consequently, it does not address the context or the user's questions at all, resulting in a complete lack of alignment.\n",
-      "--------------------------------------------------\n",
-      "QA ID: 151\n",
-      "Context Awareness Score: 0.99\n",
-      "Insight: The assistant directly answered the user's query about Alquimia's founding date with the correct information matching the ground truth and stayed within the provided context. No extraneous content was added.\n",
-      "--------------------------------------------------\n",
-      "QA ID: 152\n",
-      "Context Awareness Score: 1.0\n",
-      "Insight: The assistant's response exactly matches the ground truth statement provided in the context, confirming the CEO's identity and role without adding any extraneous information. It aligns perfectly with the context's requirement.\n",
-      "--------------------------------------------------\n",
-      "QA ID: 153\n",
-      "Context Awareness Score: 0.99\n",
-      "Insight: The assistant's response exactly matches the core promise described in the context and ground truth, providing a concise statement about fixed price, fixed time, and measured outcomes. It stays fully within the intended scope without adding unrelated information.\n",
-      "--------------------------------------------------\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(f\"Total interactions evaluated: {len(metrics)}\\n\")\n",
+    "print(f\"Total sessions evaluated: {len(metrics)}\\n\")\n",
     "\n",
     "for metric in metrics:\n",
-    "    print(f\"QA ID: {metric.qa_id}\")\n",
-    "    print(f\"Context Awareness Score: {metric.context_awareness}\")\n",
-    "    print(f\"Insight: {metric.context_insight}\")\n",
+    "    print(f\"Session: {metric.session_id} | Assistant: {metric.assistant_id}\")\n",
+    "    print(f\"Overall Context Awareness: {metric.context_awareness:.2f}\")\n",
+    "    print(f\"Interactions: {metric.n_interactions}\")\n",
+    "    for interaction in metric.interactions:\n",
+    "        print(f\"  QA ID: {interaction.qa_id}\")\n",
+    "        print(f\"  Score: {interaction.context_awareness:.2f}\")\n",
+    "        print(f\"  Insight: {interaction.insight}\")\n",
+    "        if interaction.reasoning:\n",
+    "            print(f\"  Reasoning: {interaction.reasoning[:200]}...\")\n",
+    "        print()\n",
     "    print(\"-\" * 50)"
    ]
   },
@@ -257,24 +154,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Average Context Awareness: 0.42\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "avg_score = sum(m.context_awareness for m in metrics) / len(metrics)\n",
-    "print(f\"Average Context Awareness: {avg_score:.2f}\")"
+    "print(f\"Average Context Awareness across sessions: {avg_score:.2f}\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Streaming Retrievers\n",
     "\n",
@@ -282,20 +172,22 @@
     "\n",
     "- **`stream_sessions`**: Yields one full `Dataset` session at a time\n",
     "- **`stream_batches`**: Yields individual `StreamedBatch` (one QA pair + session metadata) at a time"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Mode 1: `stream_sessions` — one session at a time\n",
     "\n",
     "The retriever yields full `Dataset` sessions lazily. Processing is identical to `full_dataset` but memory usage is bounded to one session at a time.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from helpers.retriever import StreamingSessionRetriever\n",
     "\n",
@@ -307,22 +199,22 @@
     ")\n",
     "\n",
     "print(f\"stream_sessions produced {len(streaming_session_metrics)} metrics\")"
-   ],
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Mode 2: `stream_batches` — one QA pair at a time\n",
     "\n",
     "Each yielded item is a `StreamedBatch` containing `metadata` (session info) and `batch` (the individual QA pair). The metric receives one-item batches, useful for processing pipelines where QA pairs arrive independently."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from helpers.retriever import StreamingBatchRetriever\n",
     "\n",
@@ -334,10 +226,7 @@
     ")\n",
     "\n",
     "print(f\"stream_batches produced {len(streaming_batch_metrics)} metrics\")"
-   ],
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   ]
   }
  ],
  "metadata": {
@@ -356,7 +245,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/examples/context/jupyter/context.ipynb
+++ b/examples/context/jupyter/context.ipynb
@@ -23,9 +23,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "!pip install \"../../../dist/alquimia_fair_forge-3.0.0b2-py3-none-any.whl\" langchain-groq --force-reinstall"
-   ]
+   "source": "!pip install \"alquimia-fair-forge\" \"langchain-groq\""
   },
   {
    "cell_type": "markdown",

--- a/fair_forge/core/base.py
+++ b/fair_forge/core/base.py
@@ -197,6 +197,13 @@ class FairForge(ABC):
             float(np.quantile(bootstrap_means, 1.0 - alpha)),
         )
 
+    def _resolve_chat_history(self, preferred: bool) -> bool:
+        from fair_forge.schemas.common import IterationLevel
+
+        if self.level == IterationLevel.STREAM_BATCHES:
+            return False
+        return preferred
+
     def on_process_complete(self):  # noqa: B027
         """Optional hook evaluated after all dataset elements are processed. Useful for accumulator metrics."""
 

--- a/fair_forge/llm/judge.py
+++ b/fair_forge/llm/judge.py
@@ -168,8 +168,12 @@ Do not include any additional text after the JSON.
 
         if self.chat_history_enabled:
             self._chat_history.append(("human", query))
-            if response_content:
-                self._chat_history.append(("assistant", response_content))
+            parsed = result.get("structured_response") if result else None
+            assistant_content = response_content or (
+                json.dumps(parsed.model_dump() if isinstance(parsed, BaseModel) else parsed) if parsed else ""
+            )
+            if assistant_content:
+                self._chat_history.append(("assistant", assistant_content))
 
         return reasoning, result.get("structured_response") if result else None
 

--- a/fair_forge/llm/judge.py
+++ b/fair_forge/llm/judge.py
@@ -56,6 +56,10 @@ class Judge:
         mode = "enabled" if chat_history else "disabled"
         self.logger.info(f"Judge initialized with chat_history {mode}")
 
+    @property
+    def chat_history(self) -> list[tuple[str, str]]:
+        return self._chat_history
+
     def check(
         self,
         system_prompt: str,

--- a/fair_forge/llm/judge.py
+++ b/fair_forge/llm/judge.py
@@ -142,8 +142,15 @@ Do not include any additional text after the JSON.
                 parsed = result.get("structured_response")
 
                 if parsed is None and attempt < max_retries - 1:
+                    messages_val = result.get("messages", [])
+                    result_summary = {
+                        "keys": list(result.keys()),
+                        "has_structured_response": "structured_response" in result,
+                        "messages_count": len(messages_val) if isinstance(messages_val, list) else 0,
+                    }
                     self.logger.warning(
-                        f"Retry {attempt + 1}/{max_retries} - model returned invalid JSON. " f"Raw result: {result}"
+                        f"Retry {attempt + 1}/{max_retries} - model returned invalid JSON. "
+                        f"Result summary: {result_summary}"
                     )
                     continue
 

--- a/fair_forge/llm/judge.py
+++ b/fair_forge/llm/judge.py
@@ -23,14 +23,15 @@ class Judge:
     - Structured output: Uses create_agent with response_format for schema validation
     - Regex extraction: Parses JSON from model response using regex patterns
 
-    Reasoning content is automatically extracted from LangChain's
-    additional_kwargs.reasoning_content when available.
+    Each call to check() is atomic by default. When chat_history is enabled,
+    both human queries and assistant responses are preserved across calls.
 
     Args:
         model: LangChain BaseChatModel instance
         use_structured_output: If True, use create_agent with response_format
         bos_json_clause: Opening marker for JSON block (default: ```json)
         eos_json_clause: Closing marker for JSON block (default: ```)
+        chat_history: If True, accumulate conversation history across check() calls
     """
 
     def __init__(
@@ -41,6 +42,7 @@ class Judge:
         bos_json_clause: str = "```json",
         eos_json_clause: str = "```",
         verbose: bool = False,
+        chat_history: bool = False,
     ):
         self.model = model
         self.use_structured_output = use_structured_output
@@ -48,8 +50,11 @@ class Judge:
         self.bos_json_clause = bos_json_clause
         self.eos_json_clause = eos_json_clause
         self.verbose = verbose
-        self.chat_history: list[tuple[str, str]] = []
+        self.chat_history_enabled = chat_history
+        self._chat_history: list[tuple[str, str]] = []
         self.logger = VerboseLogger(verbose=verbose)
+        mode = "enabled" if chat_history else "disabled"
+        self.logger.info(f"Judge initialized with chat_history {mode}")
 
     def check(
         self,
@@ -78,6 +83,15 @@ class Judge:
             model instance (structured mode) or dict (regex mode). reasoning_content
             is extracted from LangChain's additional_kwargs when available.
         """
+        if not self.chat_history_enabled and self._chat_history:
+            self.logger.warning(
+                f"Chat history is disabled but contains {len(self._chat_history)} stale entries. Clearing."
+            )
+            self._chat_history.clear()
+
+        if self.chat_history_enabled:
+            self.logger.debug(f"Chat history has {len(self._chat_history)} entries")
+
         if self.use_structured_output and output_schema:
             return self._check_structured(system_prompt, query, data, output_schema)
         return self._check_regex(system_prompt, query, data, output_schema)
@@ -118,8 +132,7 @@ Do not include any additional text after the JSON.
             system_prompt=rendered_system,
         )
 
-        messages = [*self.chat_history, ("human", query)]
-        self.chat_history.append(("human", query))
+        messages = [*self._chat_history, ("human", query)]
 
         max_retries = 5
         result = None
@@ -129,23 +142,34 @@ Do not include any additional text after the JSON.
                 parsed = result.get("structured_response")
 
                 if parsed is None and attempt < max_retries - 1:
-                    self.logger.warning(f"Retry {attempt + 1}/{max_retries} - model returned invalid JSON")
+                    self.logger.warning(
+                        f"Retry {attempt + 1}/{max_retries} - model returned invalid JSON. " f"Raw result: {result}"
+                    )
                     continue
 
                 break
             except Exception as e:
+                self.logger.warning(f"Attempt {attempt + 1}/{max_retries} failed: {e}")
                 if "400" in str(e) and attempt < max_retries - 1:
-                    self.logger.warning(f"Retry {attempt + 1}/{max_retries} after 400 error")
                     continue
                 raise
 
         reasoning = ""
+        response_content = ""
         if result:
             for msg in reversed(result.get("messages", [])):
                 reasoning_content = getattr(msg, "additional_kwargs", {}).get("reasoning_content", "")
                 if reasoning_content:
                     reasoning = reasoning_content
+                if not response_content and hasattr(msg, "content") and msg.content:
+                    response_content = str(msg.content)
+                if reasoning and response_content:
                     break
+
+        if self.chat_history_enabled:
+            self._chat_history.append(("human", query))
+            if response_content:
+                self._chat_history.append(("assistant", response_content))
 
         return reasoning, result.get("structured_response") if result else None
 
@@ -162,13 +186,18 @@ Do not include any additional text after the JSON.
         else:
             enhanced_prompt = system_prompt
 
-        self.chat_history.append(("human", query))
-        prompt = ChatPromptTemplate.from_messages([("system", enhanced_prompt), *self.chat_history])
+        messages = [("system", enhanced_prompt), *self._chat_history, ("human", query)]
+        prompt = ChatPromptTemplate.from_messages(messages)
         chain = prompt | self.model
         response = chain.invoke(data)
         content = str(response.content)
         reasoning = response.additional_kwargs.get("reasoning_content", "")
         json_data = self._extract_json(content)
+
+        if self.chat_history_enabled:
+            self._chat_history.append(("human", query))
+            self._chat_history.append(("assistant", content))
+
         return reasoning, json_data
 
     def _extract_json(self, text: str) -> dict | None:

--- a/fair_forge/metrics/agentic.py
+++ b/fair_forge/metrics/agentic.py
@@ -375,6 +375,7 @@ Examples:
             bos_json_clause=self.bos_json_clause,
             eos_json_clause=self.eos_json_clause,
             verbose=self.verbose,
+            chat_history=False,
         )
 
         for dataset_idx, dataset in enumerate(self.dataset, 1):

--- a/fair_forge/metrics/best_of.py
+++ b/fair_forge/metrics/best_of.py
@@ -63,6 +63,7 @@ class BestOf(FairForge):
             strict=self.strict,
             bos_json_clause=self.bos_json_clause,
             eos_json_clause=self.eos_json_clause,
+            chat_history=self._resolve_chat_history(preferred=False),
         )
 
     def _build_single_contestant(self, batch: list[Batch]) -> str:

--- a/fair_forge/metrics/context.py
+++ b/fair_forge/metrics/context.py
@@ -66,6 +66,7 @@ class Context(FairForge):
             bos_json_clause=self.bos_json_clause,
             eos_json_clause=self.eos_json_clause,
             verbose=self.verbose,
+            chat_history=self._resolve_chat_history(preferred=False),
         )
 
         if session_id not in self._session_data:
@@ -108,7 +109,12 @@ class Context(FairForge):
             self._session_data[session_id]["batches"].append(interaction)
             self._session_data[session_id]["scores"].append(score)
             self._session_data[session_id]["interactions"].append(
-                ContextInteraction(qa_id=interaction.qa_id, context_awareness=score)
+                ContextInteraction(
+                    qa_id=interaction.qa_id,
+                    context_awareness=score,
+                    insight=insight,
+                    reasoning=reasoning if reasoning else None,
+                )
             )
 
     def on_process_complete(self):

--- a/fair_forge/metrics/conversational.py
+++ b/fair_forge/metrics/conversational.py
@@ -81,6 +81,7 @@ class Conversational(FairForge):
             strict=self.strict,
             bos_json_clause=self.bos_json_clause,
             eos_json_clause=self.eos_json_clause,
+            chat_history=self._resolve_chat_history(preferred=True),
         )
 
         if session_id not in self._session_data:

--- a/fair_forge/schemas/context.py
+++ b/fair_forge/schemas/context.py
@@ -8,6 +8,8 @@ from .metrics import BaseMetric
 class ContextInteraction(BaseModel):
     qa_id: str
     context_awareness: float
+    insight: str | None = None
+    reasoning: str | None = None
 
 
 class ContextMetric(BaseMetric):

--- a/papers/context/context.tex
+++ b/papers/context/context.tex
@@ -1,3 +1,18 @@
+\documentclass[11pt,a4paper]{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{amsmath,amssymb}
+\usepackage{hyperref}
+\usepackage{enumitem}
+
+\title{Context Adherence Metrics for AI Assistant Evaluation}
+\author{Alquimia AI}
+\date{}
+
+\begin{document}
+\maketitle
+
 \section{Context Adherence Metrics}
 
 The evaluation of context adherence in AI assistant responses is crucial for ensuring relevant and appropriate interactions. This section presents a framework for assessing how well an assistant's responses align with the provided context and expected outcomes. Our approach builds upon the LLM-as-a-judge paradigm introduced by Zheng et al.~\cite{zheng2023judging}, which demonstrated that strong LLMs can achieve over 80\% agreement with human preferences---matching inter-human agreement levels---when used as evaluators.
@@ -119,3 +134,8 @@ The LLM-as-a-judge approach is not without limitations. Zheng et al.~\cite{zheng
     \item Decoupling the judge model from the assistant under evaluation, preventing self-enhancement bias
     \item Providing explicit scoring rubrics within the system prompt to anchor the evaluation criteria
 \end{itemize}
+
+\bibliographystyle{plain}
+\bibliography{references}
+
+\end{document}

--- a/papers/context/references.bib
+++ b/papers/context/references.bib
@@ -1,0 +1,27 @@
+@inproceedings{zheng2023judging,
+  title     = {Judging {LLM}-as-a-Judge with {MT}-Bench and Chatbot Arena},
+  author    = {Zheng, Lianmin and Chiang, Wei-Lin and Sheng, Ying and Zhuang, Siyuan and Wu, Zhanghao and Zhuang, Yonghao and Lin, Zi and Li, Zhuohan and Li, Dacheng and Xing, Eric P. and Zhang, Hao and Gonzalez, Joseph E. and Stoica, Ion},
+  booktitle = {Advances in Neural Information Processing Systems},
+  year      = {2023}
+}
+
+@inproceedings{wei2022chain,
+  title     = {Chain-of-Thought Prompting Elicits Reasoning in Large Language Models},
+  author    = {Wei, Jason and Wang, Xuezhi and Schuurmans, Dale and Bosma, Maarten and Ichter, Brian and Xia, Fei and Chi, Ed and Le, Quoc V. and Zhou, Denny},
+  booktitle = {Advances in Neural Information Processing Systems},
+  year      = {2022}
+}
+
+@book{gamma1994design,
+  title     = {Design Patterns: Elements of Reusable Object-Oriented Software},
+  author    = {Gamma, Erich and Helm, Richard and Johnson, Ralph and Vlissides, John},
+  year      = {1994},
+  publisher = {Addison-Wesley}
+}
+
+@software{pydantic2024,
+  title   = {Pydantic: Data Validation Using Python Type Hints},
+  author  = {{Pydantic Team}},
+  year    = {2024},
+  url     = {https://docs.pydantic.dev/}
+}

--- a/tests/llm/test_judge.py
+++ b/tests/llm/test_judge.py
@@ -32,7 +32,7 @@ class TestJudge:
         assert judge.bos_json_clause == "```json"
         assert judge.eos_json_clause == "```"
         assert judge.chat_history_enabled is False
-        assert judge._chat_history == []
+        assert judge.chat_history == []
 
     def test_initialization_with_structured_output(self, mock_model):
         """Test Judge initialization with structured output enabled."""

--- a/tests/llm/test_judge.py
+++ b/tests/llm/test_judge.py
@@ -31,7 +31,8 @@ class TestJudge:
         assert judge.use_structured_output is False
         assert judge.bos_json_clause == "```json"
         assert judge.eos_json_clause == "```"
-        assert judge.chat_history == []
+        assert judge.chat_history_enabled is False
+        assert judge._chat_history == []
 
     def test_initialization_with_structured_output(self, mock_model):
         """Test Judge initialization with structured output enabled."""
@@ -205,8 +206,8 @@ class TestJudge:
         assert result == {"score": 0.5}
 
     @patch("fair_forge.llm.judge.ChatPromptTemplate")
-    def test_chat_history_accumulates(self, mock_template, mock_model):
-        """Test that chat history accumulates across calls."""
+    def test_chat_history_disabled_by_default(self, mock_template, mock_model):
+        """Test that chat history does not accumulate when disabled."""
         mock_response = MagicMock()
         mock_response.content = '```json\n{"result": 1}\n```'
         mock_response.additional_kwargs = {}
@@ -219,15 +220,34 @@ class TestJudge:
         mock_template.from_messages.return_value = mock_prompt
 
         judge = Judge(model=mock_model)
-        assert len(judge.chat_history) == 0
-
         judge.check("System", "Query 1", {})
-        assert len(judge.chat_history) == 1
-        assert judge.chat_history[0] == ("human", "Query 1")
+        judge.check("System", "Query 2", {})
+        assert len(judge._chat_history) == 0
+
+    @patch("fair_forge.llm.judge.ChatPromptTemplate")
+    def test_chat_history_accumulates_when_enabled(self, mock_template, mock_model):
+        """Test that chat history accumulates human and assistant messages when enabled."""
+        mock_response = MagicMock()
+        mock_response.content = '```json\n{"result": 1}\n```'
+        mock_response.additional_kwargs = {}
+
+        mock_chain = MagicMock()
+        mock_chain.invoke.return_value = mock_response
+
+        mock_prompt = MagicMock()
+        mock_prompt.__or__ = MagicMock(return_value=mock_chain)
+        mock_template.from_messages.return_value = mock_prompt
+
+        judge = Judge(model=mock_model, chat_history=True)
+        judge.check("System", "Query 1", {})
+        assert len(judge._chat_history) == 2
+        assert judge._chat_history[0] == ("human", "Query 1")
+        assert judge._chat_history[1][0] == "assistant"
 
         judge.check("System", "Query 2", {})
-        assert len(judge.chat_history) == 2
-        assert judge.chat_history[1] == ("human", "Query 2")
+        assert len(judge._chat_history) == 4
+        assert judge._chat_history[2] == ("human", "Query 2")
+        assert judge._chat_history[3][0] == "assistant"
 
     @patch("fair_forge.llm.judge.ChatPromptTemplate")
     def test_check_json_with_whitespace(self, mock_template, mock_model):

--- a/tests/metrics/test_best_of.py
+++ b/tests/metrics/test_best_of.py
@@ -123,6 +123,7 @@ class TestBestOfMetric:
             strict=True,
             bos_json_clause="[",
             eos_json_clause="]",
+            chat_history=False,
         )
 
     @patch("fair_forge.metrics.best_of.Judge")

--- a/tests/metrics/test_context.py
+++ b/tests/metrics/test_context.py
@@ -75,6 +75,8 @@ class TestContextMetric:
         assert len(metric.interactions) == 2
         assert metric.interactions[0].qa_id == "qa_001"
         assert metric.interactions[0].context_awareness == pytest.approx(0.85)
+        assert metric.interactions[0].insight == "Good context awareness"
+        assert metric.interactions[0].reasoning == "I analyzed the context..."
 
     @patch("fair_forge.metrics.context.Judge")
     def test_batch_session_accumulation(self, mock_judge_class, mock_model):
@@ -89,6 +91,8 @@ class TestContextMetric:
 
         assert len(context.metrics) == 1
         assert context.metrics[0].n_interactions == 2
+        assert context.metrics[0].interactions[0].insight == "ok"
+        assert context.metrics[0].interactions[0].reasoning is None
 
     @patch("fair_forge.metrics.context.Judge")
     def test_batch_multiple_sessions(self, mock_judge_class, mock_model):
@@ -180,6 +184,7 @@ class TestContextMetric:
             bos_json_clause="[",
             eos_json_clause="]",
             verbose=False,
+            chat_history=False,
         )
 
     @patch("fair_forge.metrics.context.Judge")

--- a/tests/metrics/test_conversational.py
+++ b/tests/metrics/test_conversational.py
@@ -191,6 +191,7 @@ class TestConversationalMetric:
             strict=True,
             bos_json_clause="[",
             eos_json_clause="]",
+            chat_history=True,
         )
 
     @patch("fair_forge.metrics.conversational.Judge")


### PR DESCRIPTION
## Summary

- **Judge chat history fix**: Each `check()` call is now stateless by default. Previously, human queries accumulated in the chat history without their corresponding assistant responses, confusing models (especially on Groq) and causing invalid JSON outputs. Now `chat_history=False` by default, and when enabled (`chat_history=True`), both human and assistant messages are preserved.

- **`_resolve_chat_history()` on FairForge base**: Automatically disables chat history when the retriever operates in `stream_batches` mode, since each batch is a single QA pair and history has no meaning. Metrics declare their preference (`Conversational` prefers `True`, `Context`/`BestOf` prefer `False`), but the base enforces the override.

- **Context insight and reasoning fields**: `ContextInteraction` now includes `insight` and `reasoning` fields, and `Context.batch()` populates them from the judge response. The example notebook was updated to reflect the session-level `ContextMetric` structure.

- **LaTeX paper**: Added document preamble, bibliography file (`references.bib`), and expanded `.gitignore` to cover all LaTeX build artifacts.